### PR TITLE
Avoid unnecessary dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_namespace_packages, setup
 
 REQUIREMENTS = [
     "pyansys-docker>=5.0.4",
-    "grpcio_tools>=1.23.0",
+    "protobuf>=3.9.1",
     "grpcio>=1.23.0",
     "requests>=2.20.1",
 ]


### PR DESCRIPTION
pyensight should install into the commonfiles Ansys CPython w/o the need to install/update other modules.  This change fixes the 'grpc/protobuf' issues.