### PR TITLE
Session close on garbage collection

### DIFF
--- a/src/ansys/pyensight/session.py
+++ b/src/ansys/pyensight/session.py
@@ -99,6 +99,9 @@ class Session:
         s += f"ws_port={self.ws_port}, session_directory=r'{self.launcher.session_directory}')"
         return s
 
+    def __del__(self):
+        self.close()
+
     @property
     def jupyter_notebook(self) -> bool:
         """


### PR DESCRIPTION
When a session (that controls an EnSight session) is garbage collected, the EnSight instance is stopped.