### PR TITLE
Convert docs to '::' style

### DIFF
--- a/src/ansys/pyensight/locallauncher.py
+++ b/src/ansys/pyensight/locallauncher.py
@@ -35,8 +35,11 @@ class LocalLauncher(pyensight.Launcher):
             "envision" is also available.
 
     Examples:
-        >>> from ansys.pyensight import LocalLauncher
-        >>> session = LocalLauncher(ansys_installation='/ansys_inc/v222').start()
+        ::
+
+            from ansys.pyensight import LocalLauncher
+            session = LocalLauncher(ansys_installation='/ansys_inc/v222').start()
+
     """
 
     def __init__(


### PR DESCRIPTION
Make it easier to copy examples cleanly.
Add a testing hook to make  it possible to leave the service running.