### PR TITLE
Allow fnmatch in replacement XML

### DIFF
--- a/doc/replacements/ensobjs_attributes.xml
+++ b/doc/replacements/ensobjs_attributes.xml
@@ -1,0 +1,16 @@
+<docstrings>
+
+<override namespace="ensight.objs.ENS_*.HANDLES_ENABLED">
+<description>
+Control the display and use of EnSight click and go handles for an object
+
+EnSight allows for direct interaction with many objects via click and go handles.
+The handles allow things like annotations and viewports to be moved or resized.
+They allow for the adjustment of values for clip planes and palette dynamic ranges.
+In some situations, allowing the user to directly adjust these values can be
+undesirable.  Setting this attribute to zero disables display of and interaction
+with click and go handles for the specific object instance.
+</description>
+</override>
+
+</docstrings>

--- a/doc/replacements/example.xml
+++ b/doc/replacements/example.xml
@@ -38,4 +38,5 @@ Returns:
     The queried value
 </description>
 </override>
+
 </docstrings>

--- a/src/ansys/pyensight/session.py
+++ b/src/ansys/pyensight/session.py
@@ -187,7 +187,7 @@ class Session:
     @property
     def cei_suffix(self) -> str:
         """
-        The "suffix" string (e.g. "222" or 231") the connected EnSight session.
+        The suffix string, 222 for example, of the connected EnSight session.
         """
         return self._cei_suffix
 
@@ -195,7 +195,7 @@ class Session:
     def jupyter_notebook(self) -> bool:
         """
         True if the session is running in a jupyter notebook and should use
-        display features of that interface
+        display features of that interface.
         """
         return self._jupyter_notebook
 
@@ -284,13 +284,13 @@ class Session:
         Args:
             what:
                 The type of scene display to generate.  Three values are supported: 'image',
-                'webgl', 'remote'.
+                'webgl', 'remote', 'deep_pixel'.
             width:
                 The width of the rendered entity
             height:
                 The height of the rendered entity
             temporal:
-                If True, include all timesteps
+                If True, include all timesteps in 'webgl' views
 
         Returns:
             URL for the renderable.


### PR DESCRIPTION
It is now legal to include glob-style matching in the namespace specification for attribute replacement.  This makes it a lot easier to support common properties (e.g. ENSOBJ.VISIBLE).