### PR TITLE
Allow proxy add_callback proxy object targets

### DIFF
--- a/doc/source/examples_source/50-advanced/00-events.py
+++ b/doc/source/examples_source/50-advanced/00-events.py
@@ -44,7 +44,7 @@ def part_list(name: str):
     partlist_disp.value = f"Event: {name}"
 
 
-session.add_callback("ensight.objs.core", "partlist_name", ["PARTS"], part_list)
+session.add_callback(session.ensight.objs.core, "partlist_name", ["PARTS"], part_list)
 
 
 ###############################################################################

--- a/src/ansys/pyensight/session.py
+++ b/src/ansys/pyensight/session.py
@@ -694,7 +694,7 @@ class Session:
         self.cmd(script, do_eval=False)
 
     def add_callback(
-        self, target: str, tag: str, attr_list: list, method: Callable, compress: bool = True
+        self, target: Any, tag: str, attr_list: list, method: Callable, compress: bool = True
     ) -> None:
         """Register a callback with an event tuple
 
@@ -708,7 +708,8 @@ class Session:
         Args:
             target:
                 The name of the target object or the name of a class as a string to
-                match all objects of that class.
+                match all objects of that class.  Note: a proxy class reference is
+                also allowed (e.g. session.ensight.objs.core).
             tag:
                 The unique name for the callback. A tag can end with macros of
                 the form {{attrname}} to return the value of an attribute of the
@@ -765,6 +766,8 @@ class Session:
         flags = ""
         if compress:
             flags = ",flags=ensight.objs.EVENTMAP_FLAG_COMP_GLOBAL"
+        if hasattr(target, "__OBJID__"):
+            target = self.remote_obj(target.__OBJID__)
         cmd = f"ensight.objs.addcallback({target},None,"
         cmd += f"'{self._grpc.prefix()}{tag}',attrs={repr(attr_list)}{flags})"
         callback_id = self.cmd(cmd)


### PR DESCRIPTION
The add_callback method now allows for proxy objects to be specified as targets.