### PR TITLE
Remove PDF reference from release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -173,10 +173,6 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: Documentation-pdf
-
-      - uses: actions/download-artifact@v2
-        with:
           name: Documentation-html
           path: ~/html
 
@@ -208,7 +204,6 @@ jobs:
           files: |
             ./**/*.whl
             ./**/*.zip
-            ./**/*.pdf
 
   build-failure:
     name: Teams notify on failure


### PR DESCRIPTION
pyensight does not build .pdf files.