### PR TITLE
Different approach to timeouts

### DIFF
--- a/src/ansys/pyensight/dockerlauncher.py
+++ b/src/ansys/pyensight/dockerlauncher.py
@@ -59,6 +59,7 @@ class DockerLauncher(pyensight.Launcher):
     ) -> None:
         super().__init__()
 
+        self._timeout = timeout
         self._data_directory: str = data_directory
         self._container = None
 

--- a/src/ansys/pyensight/session.py
+++ b/src/ansys/pyensight/session.py
@@ -173,7 +173,7 @@ class Session:
                     return
                 except OSError:
                     pass
-            self._grpc.connect()
+            self._grpc.connect(timeout=self._timeout)
         raise RuntimeError("Unable to establish a gRPC connection to EnSight.")
 
     @property


### PR DESCRIPTION
Attempt to use the future timeout vs timeout looping for EnSight gRPC establishment. Fix an issue with docker timeouts.