### PR TITLE
revert image name change for ensight_dev

### DIFF
--- a/src/ansys/pyensight/dockerlauncher.py
+++ b/src/ansys/pyensight/dockerlauncher.py
@@ -66,7 +66,7 @@ class DockerLauncher(pyensight.Launcher):
         # get the optional user specified image name
         self._image_name: str = "ghcr.io/ansys/ensight"
         if use_dev:
-            self._image_name = "ghcr.io/ansys/ensight_dev2"
+            self._image_name = "ghcr.io/ansys/ensight_dev"
         if docker_image_name:
             self._image_name = docker_image_name
 


### PR DESCRIPTION
A previous PR changed the Docker Image name from ensight_dev to ensight_dev2. Revert that change.