### PR TITLE
two more ensight actual tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store",
         default="/ansys_inc/v222/",
     )
+    parser.addoption("--use-local-launcher", default=False, action="store_true")
 
 
 @pytest.fixture

--- a/tests/example_tests/test_asynchronous_events.py
+++ b/tests/example_tests/test_asynchronous_events.py
@@ -18,19 +18,22 @@ import os
 import shutil
 from urllib.parse import parse_qs, urlparse
 
+import pytest
+
 from ansys.pyensight import DockerLauncher, LocalLauncher
 
 
-def test_async_events(tmpdir):
+def test_async_events(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     shutil.copytree(
         os.path.join(os.path.dirname(__file__), "test_data", "guard_rail"),
         os.path.join(data_dir, "guard_rail"),
     )
-    try:
-        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
-    except Exception:
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
         launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
     ###############################################################################
     # Simple event
@@ -67,7 +70,10 @@ def test_async_events(tmpdir):
     # call.  The name of the attribute is always returned as "enum" and the id of the object
     # will be returned in "uid".
 
-    session.load_data("/data/guard_rail/crash.case")
+    if use_local:
+        session.load_data(os.path.join(data_dir, "guard_rail", "crash.case"))
+    else:
+        session.load_data("/data/guard_rail/crash.case")
     session.show("remote")
 
     ###############################################################################

--- a/tests/example_tests/test_designpoints.py
+++ b/tests/example_tests/test_designpoints.py
@@ -1,15 +1,18 @@
 import glob
 import os
 
+import pytest
+
 from ansys.pyensight import DockerLauncher, LocalLauncher
 
 
-def test_designpoints(tmpdir):
+def test_designpoints(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
-    try:
-        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
-    except Exception:
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
         launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
     session.load_example("elbow_dp0_dp1.ens")
     image = session.show("image", width=800, height=600)

--- a/tests/example_tests/test_renderables.py
+++ b/tests/example_tests/test_renderables.py
@@ -2,21 +2,27 @@ import glob
 import os
 import shutil
 
+import pytest
+
 from ansys.pyensight import DockerLauncher, LocalLauncher
 
 
-def test_renderables(tmpdir):
+def test_renderables(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     shutil.copytree(
         os.path.join(os.path.dirname(__file__), "test_data", "guard_rail"),
         os.path.join(data_dir, "guard_rail"),
     )
-    try:
-        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
-    except Exception:
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
         launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
-    session.load_data("/data/guard_rail/crash.case")
+    if use_local:
+        session.load_data(os.path.join(data_dir, "guard_rail", "crash.case"))
+    else:
+        session.load_data("/data/guard_rail/crash.case")
     # Apply displacements
     displacement = session.ensight.objs.core.VARIABLES["displacement"][0]
     session.ensight.objs.core.PARTS.set_attr("DISPLACEBY", displacement)


### PR DESCRIPTION
tested on apxwintest2 with podman.
Had to fix the session file downloaded by the design points case since it referred absolute paths and not the files included in the session file

I have also added a command line option to switch the tests to use the local launcher instead of the docker launcher for ADO builds