### PR TITLE
unit test fails on ADO builds, fixed

### DIFF
--- a/tests/unit_tests/test_locallauncher.py
+++ b/tests/unit_tests/test_locallauncher.py
@@ -55,6 +55,12 @@ def test_get_cei_install_directory(mocker):
     # cleans it, to check all the paths
     if f"AWP_ROOT{version}" in os.environ:
         del os.environ[f"AWP_ROOT{version}"]
+    try:
+        import enve
+
+        second_path = enve.home()
+    except ModuleNotFoundError:
+        pass
     os.environ[f"AWP_ROOT{version}"] = second_path
     assert method(None) == os.path.join(second_path, "CEI")
     exists.return_value = False


### PR DESCRIPTION
Small issue.
When running the unit tests on the ADO builds the enve module is available, and this has got priority over the value of AWP_ROOT232, causing a failure

The trick is to try to import the enve module and get its value, and use it instead of the mocked path, if available