### PR TITLE
use http link when using local launcher

### DIFF
--- a/tests/example_tests/test_designpoints.py
+++ b/tests/example_tests/test_designpoints.py
@@ -9,12 +9,14 @@ from ansys.pyensight import DockerLauncher, LocalLauncher
 def test_designpoints(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     use_local = pytestconfig.getoption("use_local_launcher")
+    root = None
     if use_local:
         launcher = LocalLauncher()
+        root = "http://s3.amazonaws.com/www3.ensight.com/PyEnSight/ExampleData"
     else:
         launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
-    session.load_example("elbow_dp0_dp1.ens")
+    session.load_example("elbow_dp0_dp1.ens", root=root)
     image = session.show("image", width=800, height=600)
     image.download(data_dir)
     print([p.PATHNAME for p in session.ensight.objs.core.PARTS])

--- a/tests/example_tests/test_queries.py
+++ b/tests/example_tests/test_queries.py
@@ -11,12 +11,14 @@ from ansys.pyensight import DockerLauncher, LocalLauncher
 def test_queries(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     use_local = pytestconfig.getoption("use_local_launcher")
+    root = None
     if use_local:
         launcher = LocalLauncher()
+        root = "http://s3.amazonaws.com/www3.ensight.com/PyEnSight/ExampleData"
     else:
         launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
-    session.load_example("waterbreak.ens")
+    session.load_example("waterbreak.ens", root=root)
     # Get the core part and variable objects
     var = session.ensight.objs.core.VARIABLES["p"][0]
     part = session.ensight.objs.core.PARTS["default_region"][0]


### PR DESCRIPTION
ADO builds machines have issues when trying to download the session files from the s3 bucket, since the requests module cannot verify the s3 ssl certificate.

The PR just changes the root for downloading the files from https to http in the two specific tests