### PR TITLE
Remove broken links

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -2,7 +2,7 @@ PyEnSight
 =========
 Version: |version|
 
-|pyansys| |python| |ci| |coverage| |MIT| |pre-commit| |black| |isort| |bandit|
+|pyansys| |python| |coverage| |MIT| |pre-commit| |black| |isort| |bandit|
 
 .. |pyansys| image:: https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC
    :target: https://docs.pyansys.com/
@@ -25,9 +25,6 @@ Version: |version|
 .. |bandit| image:: https://img.shields.io/badge/security-bandit-yellow.svg
     :target: https://github.com/PyCQA/bandit
     :alt: Security Status
-
-.. |ci| image:: https://github.com/pyansys/pyensight/actions/workflows/ci_cd.yml/badge.svg?branch=main
-   :target: https://github.com/pyansys/pyensight/actions?query=branch%3Amain
 
 .. |coverage| image:: /_static/coverage.svg
    :target: https://ensight.docs.pyansys.com/dev


### PR DESCRIPTION
The CI status link required a login to generate the badge.  It has been removed.  It might be re-introduced when the project goes public.