### PR TITLE
check if egl is available and use it

### DIFF
--- a/src/ansys/pyensight/dockerlauncher.py
+++ b/src/ansys/pyensight/dockerlauncher.py
@@ -15,6 +15,7 @@ Examples:
 """
 import os.path
 import re
+import subprocess
 from typing import Optional
 import uuid
 
@@ -177,6 +178,8 @@ class DockerLauncher(pyensight.Launcher):
 
         # FIXME_MFK: probably need a unique name for our container
         # in case the user launches multiple sessions
+        egl_env = os.environ.get("PYENSIGHT_FORCE_ENSIGHT_EGL")
+        use_egl = use_egl or egl_env or self._has_egl()
         if use_egl:
             self._container = self._docker_client.containers.run(
                 self._image_name,
@@ -303,3 +306,12 @@ class DockerLauncher(pyensight.Launcher):
             self._container.stop()
             self._container.remove()
             self._container = None
+
+    def _has_egl(self) -> bool:
+        if self._is_windows():
+            return False
+        try:
+            subprocess.check_output("nvidia-smi")
+            return True
+        except subprocess.CalledProcessError:
+            return False

--- a/src/ansys/pyensight/launcher.py
+++ b/src/ansys/pyensight/launcher.py
@@ -11,6 +11,7 @@ Examples:
 
 """
 import os.path
+import platform
 import socket
 from typing import List, Optional
 
@@ -156,3 +157,19 @@ class Launcher:
         if len(ports) < count:
             return None
         return ports
+
+    def _has_egl(self) -> bool:
+        """Return True if the system supports the EGL launch.
+
+        Returns:
+            A bool value that is True if the system supports the EGL launch.
+        """
+        raise RuntimeError("Unsupported method for this configuration")
+
+    def _is_windows(self) -> None:
+        """Return True if it is Windows
+
+        Returns:
+            a bool that is True if the platform is Windows
+        """
+        return platform.system() == "Windows"


### PR DESCRIPTION
I have added some checks for using egl:

1) I have added to local launcher a use_egl argument to be consistent with DockerLauncher to force egl
2) I have also added the possibility of forcing egl with an env variable
3) If both 1 and 2 are false, I am trying to detect egl:
   a) If locallauncher and linux, I am running the egl test from the bin directory to check if it is possible to use it
   b) If dockerlauncher, the container is already built to use nvidia, so the check has to be on the calling system rather than the container. So, if on linux I am checking for the gpu availability. On windows it will be False
   
   If 1 2 or 3 are true, the egl option will be added to the command line
   
This commit fixes #21 