### PR TITLE
Nightly docs builds need LM

### DIFF
--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Full Documentation Build
         run: |
           make -C doc html
+        env:
+          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+
       - name: Upload documentation HTML artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Nightly docs builds use DockerLauncher and thus require the license manager server specification.