### PR TITLE
Change in the python invoked for building docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -66,7 +66,7 @@ autoapi_options = [
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/dev", None),
+    "python": ("https://docs.python.org/3", None),
     # kept here as an example
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     # "numpy": ("https://numpy.org/devdocs", None),


### PR DESCRIPTION
Change: use stable version python instead of dev, as per pyansys people suggestion