### PR TITLE
Fix module naming in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,11 +53,11 @@ Include installation directions.  Note that this README will be
 included in your PyPI package, so be sure to include ``pip``
 directions along with developer installation directions.  For example.
 
-Install ansys-pyensight with:
+Install ansys-ensight with:
 
 .. code::
 
-   pip install ansys-pyensight
+   pip install ansys-ensight
 
 
 Development
@@ -183,7 +183,7 @@ License
 -------
 ``PyEnSight`` is licensed under the MIT license.
 
-This module, ``ansys-pyensight`` makes no commercial claim over Ansys whatsoever.
+This module, ``ansys-ensight`` makes no commercial claim over Ansys whatsoever.
 This tool extends the functionality of ``EnSight`` by adding a remote Python interface
 to EnSight without changing the core behavior or license of the original
 software.  The use of interactive EnSight control by ``PyEnSight`` requires a

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -12,14 +12,14 @@ on the Ansys website.
 
 Installation
 ------------
-The ``ansys-pyensight`` package supports Python 3.7 through
+The ``ansys-ensight`` package supports Python 3.7 through
 Python 3.10 on Windows and Linux.
 
 Install the latest package with this code:
 
 .. code::
 
-   pip install ansys-pyensight
+   pip install ansys-ensight
 
 
 If you plan on doing local *development* of PyEnSight on Linux,


### PR DESCRIPTION
Originally, the module was named:

ansys-pyensight

it had previously been renamed ansys-ensight, but the docs did not reflect this.