### PR TITLE
Fix issues with calling start() repeatedly

### DIFF
--- a/src/ansys/pyensight/dockerlauncher.py
+++ b/src/ansys/pyensight/dockerlauncher.py
@@ -61,11 +61,9 @@ class DockerLauncher(pyensight.Launcher):
         data_directory: str,
         docker_image_name: Optional[str] = None,
         use_dev: Optional[bool] = False,
-        timeout: Optional[float] = 120.0,
-        use_egl: Optional[bool] = False,
-        use_sos: Optional[int] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(timeout=timeout, use_egl=use_egl, use_sos=use_sos)
+        super().__init__(**kwargs)
 
         self._data_directory: str = data_directory
         self._container = None
@@ -140,6 +138,9 @@ class DockerLauncher(pyensight.Launcher):
             RuntimeError:
                 variety of error conditions.
         """
+        tmp_session = super().start()
+        if tmp_session:
+            return tmp_session
         # gRPC port, VNC port, websocketserver ws, websocketserver html
         ports = self._find_unused_ports(4)
         if ports is None:
@@ -316,6 +317,7 @@ class DockerLauncher(pyensight.Launcher):
             self._container.stop()
             self._container.remove()
             self._container = None
+        super().stop()
 
     def _has_egl(self) -> bool:
         if self._is_windows():

--- a/src/ansys/pyensight/dockerlauncherenshell.py
+++ b/src/ansys/pyensight/dockerlauncherenshell.py
@@ -80,13 +80,11 @@ class DockerLauncherEnShell(pyensight.Launcher):
         data_directory: Optional[str] = None,
         docker_image_name: Optional[str] = None,
         use_dev: Optional[bool] = False,
-        timeout: Optional[float] = 120.0,
-        use_egl: Optional[bool] = False,
-        use_sos: Optional[int] = None,
         channel: Optional[grpc.Channel] = None,
         pim_instance: Optional[Any] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(timeout=timeout, use_egl=use_egl, use_sos=use_sos)
+        super().__init__(**kwargs)
 
         self._data_directory = data_directory
         self._enshell_grpc_channel = channel
@@ -199,6 +197,9 @@ class DockerLauncherEnShell(pyensight.Launcher):
             RuntimeError:
                 variety of error conditions.
         """
+        tmp_session = super().start()
+        if tmp_session:
+            return tmp_session
 
         # Launch the EnSight Docker container locally as a detached container
         # initially running EnShell over the first gRPC port. Then launch EnSight
@@ -444,6 +445,7 @@ class DockerLauncherEnShell(pyensight.Launcher):
         if self._pim_instance is not None:
             self._pim_instance.delete()
             self._pim_instance = None
+        super().stop()
 
     def _has_egl(self) -> bool:
         if self._is_windows():
@@ -454,6 +456,7 @@ class DockerLauncherEnShell(pyensight.Launcher):
         except (subprocess.CalledProcessError, FileNotFoundError):
             return False
 
-    def _get_host_port(self, uri: str) -> tuple:
+    @staticmethod
+    def _get_host_port(uri: str) -> tuple:
         parse_results = urllib3.util.parse_url(uri)
         return (parse_results.host, parse_results.port)

--- a/src/ansys/pyensight/locallauncher.py
+++ b/src/ansys/pyensight/locallauncher.py
@@ -50,8 +50,10 @@ class LocalLauncher(pyensight.Launcher):
         ::
 
             from ansys.pyensight import LocalLauncher
-            session = LocalLauncher(ansys_installation='/ansys_inc/v222').start()
-
+            # Create one EnSight session
+            session1 = LocalLauncher(ansys_installation='/ansys_inc/v232').start()
+            # Create a second session (a new LocalLauncher instance is required)
+            session2 = LocalLauncher(ansys_installation='/ansys_inc/v232').start()
     """
 
     def __init__(
@@ -59,11 +61,9 @@ class LocalLauncher(pyensight.Launcher):
         ansys_installation: Optional[str] = None,
         application: Optional[str] = "ensight",
         batch: Optional[bool] = True,
-        timeout: Optional[float] = 120.0,
-        use_egl: Optional[bool] = False,
-        use_sos: Optional[int] = None,
+        **kwargs,
     ) -> None:
-        super().__init__(timeout=timeout, use_egl=use_egl, use_sos=use_sos)
+        super().__init__(**kwargs)
 
         # get the user selected installation directory
         self._install_path: str = self.get_cei_install_directory(ansys_installation)
@@ -104,6 +104,9 @@ class LocalLauncher(pyensight.Launcher):
             RuntimeError:
                 if the necessary number of ports could not be allocated.
         """
+        tmp_session = super().start()
+        if tmp_session:
+            return tmp_session
         if self._ports is None:
             # session directory and UUID
             self._secret_key = str(uuid.uuid1())
@@ -217,6 +220,7 @@ class LocalLauncher(pyensight.Launcher):
             try:
                 shutil.rmtree(self.session_directory)
                 self._ports = None
+                super().stop()
                 return
             except PermissionError:
                 pass


### PR DESCRIPTION
Launcher subclasses are not allowed to have start() called twice.  Handled by the base class.