### PR TITLE
Fix fastdocs target

### DIFF
--- a/doc/source/class_documentation.rst
+++ b/doc/source/class_documentation.rst
@@ -24,22 +24,22 @@ PyEnSight using the ``ansys.pyensight.Session.ensight`` interface.
    :hidden:
    :maxdepth: 4
 
-   calc_functions
-   rest_api/rest_api
    native_documentation
    object_documentation
+   calc_functions
+   rest_api/rest_api
 
 
 .. autosummary::
    :toctree: _autosummary/
 
+   pyensight.enscontext.EnsContext
    pyensight.Launcher
    pyensight.LocalLauncher
    pyensight.DockerLauncher
-   pyensight.Session
    pyensight.renderable.Renderable
-   pyensight.enscontext.EnsContext
-   pyensight.utils.views.Views
-   pyensight.utils.query.Query
+   pyensight.Session
    pyensight.utils.parts.Parts
+   pyensight.utils.query.Query
    pyensight.utils.support.Support
+   pyensight.utils.views.Views

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -142,7 +142,11 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 source_suffix = ".rst"
 if os.environ.get("FASTDOCS", "0") == "1":
-    exclude_patterns = ["class_documentation.rst"]
+    exclude_patterns = [
+        "class_documentation.rst",
+        "object_documentation.rst",
+        "native_documentation.rst",
+    ]
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
if fastdocs is  used, skip all .rst files using autosummary.   Rearrange some of the TOC items.