### PR TITLE
missing dependency for pyensight wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ REQUIREMENTS = [
     "requests>=2.20.1",
     "urllib3>=1.25.4",
     "dill>=0.3.5.1",
-    "typing-extensions>=4.5.0"
+    "typing-extensions>=4.5.0",
 ]
 
 curr_dir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
current PyEnSight wheels are broken since typing-extensions is not in the requirements, just tried to install in a virtual env and it complains.
Adding the dependency in the requirements fixes the issue, tried locally