### PR TITLE
fix versions location for gh-pages

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,7 +28,7 @@ html_favicon = ansys_favicon
 html_theme_options = {
     "check_switcher": False,
     "switcher": {
-        "json_url": f"https://{cname}/release/versions.json",
+        "json_url": f"https://{cname}/versions.json",
         "version_match": get_version_match(__version__),
     },
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],


### PR DESCRIPTION
Point to the root versions.json in gh-pages to get all the documentation and not just the dev documentation