### PR TITLE
Add links for doc and cheat sheet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,12 +48,23 @@ from Python. With PyEnSight, you can perform these essential actions:
 
 Documentation and Issues
 ------------------------
-For comprehensive information on PyEnSight, see the latest release
-`documentation <https://ensight.docs.pyansys.com/>`_.
+Documentation for the latest stable release of PyEnSight is hosted at
+`PyEnSight documentation <https://ensight.docs.pyansys.com/version/stable/>`_.
 
-On the `PyEnSight Issues <https://github.com/ansys/pyensight/issues>`_
-page, you can create issues to submit questions, report bugs, and
-request new features. This is the best place to post questions and code.
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pyensight_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pyensight_cheat_sheet.pdf>`_ the
+PyEnSight cheat sheet. This one-page reference provides syntax rules and commands
+for using PyEnSight.
+
+On the `PyEnSight Issues <https://github.com/ansys/pyensight/issues>`_ page, you can
+create issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ for using PyEnSight.
 
 On the `PyEnSight Issues <https://github.com/ansys/pyensight/issues>`_ page, you can
 create issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
-page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback.
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -50,13 +50,23 @@ remote, or desktop apps.
 
 Documentation and issues
 ------------------------
-In addition to installation and usage information, the `PyEnSight documentation
-<https://ensight.docs.pyansys.com/>`_ provides API member descriptions, examples,
-and contribution information.
+Documentation for the latest stable release of PyEnSight is hosted at
+`PyEnSight documentation <https://ensight.docs.pyansys.com/version/stable/>`_.
 
-On the `PyEnSight Issues <https://github.com/ansys/pyensight/issues>`_ page,
-you can create issues to submit questions, report bugs, and request new features.
-This is the best place to post questions and code.
+In the upper right corner of the documentation's title bar, there is an option for switching from
+viewing the documentation for the latest stable release to viewing the documentation for the
+development version or previously released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pyensight_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pyensight_cheat_sheet.pdf>`_ the
+PyEnSight cheat sheet. This one-page reference provides syntax rules and commands
+for using PyEnSight.
+
+On the `PyEnSight Issues <https://github.com/ansys/pyensight/issues>`_ page, you can
+create issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 License
 -------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -64,7 +64,7 @@ for using PyEnSight.
 
 On the `PyEnSight Issues <https://github.com/ansys/pyensight/issues>`_ page, you can
 create issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
-page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback. 
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback.
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 


### PR DESCRIPTION
Per Landon’s request in the PyAnsys Global AFT on 7/26/23, add links to the PyEnSight cheat sheet from this library's documentation.

Note: This library doesn't reuse the README content in the overall index.rst file for documentation. Consequently, I revised the "Documentation and issues" sections in both the README and the overall index.rst file.

Also, see [Issue #281](https://github.com/ansys/pyensight/issues/281). The content added to this repo couldn't link to a Discussions page for the repo because there isn't one.