### PR TITLE
Add Discussions page link to "Doc and issues" sections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,8 +61,10 @@ PyEnSight cheat sheet. This one-page reference provides syntax rules and command
 for using PyEnSight.
 
 On the `PyEnSight Issues <https://github.com/ansys/pyensight/issues>`_ page, you can
-create issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
-page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback.
+create issues to report bugs and request new features. On the
+`PyEnSight Discussions <https://github.com/ansys/pyensight/discussions>`_ page or the
+`Discussions <https://discuss.ansys.com/>`_ page on the Ansys Developer portal,
+you can post questions, share ideas, and get community feedback.
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -63,8 +63,10 @@ PyEnSight cheat sheet. This one-page reference provides syntax rules and command
 for using PyEnSight.
 
 On the `PyEnSight Issues <https://github.com/ansys/pyensight/issues>`_ page, you can
-create issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
-page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback.
+create issues to report bugs and request new features. On the
+`PyEnSight Discussions <https://github.com/ansys/pyensight/discussions>`_ page or the
+`Discussions <https://discuss.ansys.com/>`_ page on the Ansys Developer portal,
+you can post questions, share ideas, and get community feedback.
 
 To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 


### PR DESCRIPTION
The addition of a link to the repo's new Discussions page resolves Issue 281.