### PR TITLE
add option to start the gRPC connections without secret keys and add …

### DIFF
--- a/src/ansys/pyensight/core/locallauncher.py
+++ b/src/ansys/pyensight/core/locallauncher.py
@@ -131,7 +131,8 @@ class LocalLauncher(Launcher):
             # Launch EnSight
             # create the environmental variables
             local_env = os.environ.copy()
-            local_env["ENSIGHT_SECURITY_TOKEN"] = self._secret_key
+            if not local_env.get("ENSIGHT_GRPC_DISABLE_SECURITY_TOKEN"):
+                local_env["ENSIGHT_SECURITY_TOKEN"] = self._secret_key
             local_env["WEBSOCKETSERVER_SECURITY_TOKEN"] = self._secret_key
             local_env["ENSIGHT_SESSION_TEMPDIR"] = self.session_directory
             # If for some reason, the ENSIGHT_ANSYS_LAUNCH is set previously,

--- a/src/ansys/pyensight/core/session.py
+++ b/src/ansys/pyensight/core/session.py
@@ -964,6 +964,10 @@ class Session:
                 # Warn on import errors
                 print(f"Error loading ensight.utils from: '{_filename}' : {e}")
 
+    MONITOR_NEW_TIMESTEPS_OFF = "off"
+    MONITOR_NEW_TIMESTEPS_STAY_AT_CURRENT = "stay_at_current"
+    MONITOR_NEW_TIMESTEPS_JUMP_TO_END = "jump_to_end"
+
     def load_data(
         self,
         data_file: str,
@@ -972,6 +976,7 @@ class Session:
         reader_options: Optional[dict] = None,
         new_case: bool = False,
         representation: str = "3D_feature_2D_full",
+        monitor_new_timesteps: str = MONITOR_NEW_TIMESTEPS_OFF,
     ) -> None:
         """Load a dataset into the EnSight instance.
 
@@ -1076,7 +1081,7 @@ class Session:
         if result_file:
             cmds.append(f'ensight.data.result(r"""{result_file}""")')
         cmds.append("ensight.data.shift_time(1.000000, 0.000000, 0.000000)")
-        cmds.append('ensight.solution_time.monitor_for_new_steps("off")')
+        cmds.append(f'ensight.solution_time.monitor_for_new_steps("{monitor_new_timesteps}")')
         cmds.append(f'ensight.data.replace(r"""{data_file}""")')
         for cmd in cmds:
             if self.cmd(cmd) != 0:


### PR DESCRIPTION
1) Add the option, via environment variable, to start the gRPC server in EnSight without a secret key. While this option is not intended for customers, it is still useful for debugging and the only way for allowing live stream connections between EnSight and Fluent for 232 installations. So I have added it to the pull request anyway

2) Add the option to monitor new timesteps when using load_data