### PR TITLE
python support 3.12 and remove pyansys-docker fork requirement

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Installation
 ------------
 To use PyEnSight, you must have a locally installed and licensed copy of
 Ansys EnSight 2022 R2 or later. The ``ansys-pyensight-core`` package supports
-Python 3.8 through Python 3.11 on Windows and Linux.
+Python 3.9 through Python 3.12 on Windows and Linux.
 
 Two modes of installation are available:
 

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -13,6 +13,9 @@ IgnoredScopes = code, tt
 # By default, `script`, `style`, `pre`, and `figure` are ignored.
 SkippedScopes = script, style, pre, figure
 
+BlockIgnores = (?s) *({:func:` [^`]*}), \
+(?s) *({:samp:` [^`]*}),
+
 # WordTemplate specifies what Vale will consider to be an individual word.
 WordTemplate = \b(?:%s)\b
 

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -13,6 +13,7 @@ IgnoredScopes = code, tt
 # By default, `script`, `style`, `pre`, and `figure` are ignored.
 SkippedScopes = script, style, pre, figure
 
+[*.rst]
 BlockIgnores = (?s) *({:func:` [^`]*}), \
 (?s) *({:samp:` [^`]*}),
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,17 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
     "importlib-metadata>=4.0; python_version<='3.8'",
     "ansys-api-pyensight==0.3.2",
     "requests>=2.28.2",
-    "pyansys-docker>=5.0.4",
+    "docker>=6.1.0",
     "urllib3<2",
     "typing>=3.7.4.3",
     "typing-extensions>=4.5.0",
@@ -52,7 +52,7 @@ tests = [
     "pytest-mock==3.10.0",
     "urllib3==1.26.10",
     "requests>=2.28.2",
-    "pyansys-docker>=5.0.4",
+    "docker>=6.1.0",
 ]
 doc = [
     "Sphinx==7.0.1",
@@ -61,7 +61,7 @@ doc = [
     "sphinx-copybutton==0.5.2",
     "sphinx-gallery==0.13.0",
     "sphinxcontrib-mermaid==0.9.2",
-    "pyansys-docker>=5.0.4",
+    "docker>=6.1.0",
     "matplotlib==3.7.2",
     "requests>=2.28.2",
     "sphinxcontrib.jquery==4.1",
@@ -144,7 +144,7 @@ recursive = true
 exclude = ["venv/*", "tests/*"]
 
 [tool.mypy]
-python_version = 3.8
+python_version = 3.9
 strict = false
 namespace_packages = true
 explicit_package_bases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ minversion = "7.1"
 testpaths = [
     "tests",
 ]
-addopts = "--setup-show --cov=ansys.pyensight.core --cov=ansys.api.pyensight --cov-report html:coverage-html --cov-report term --cov-config=.coveragerc --capture=tee-sys --tb=native -p no:warnings"
+addopts = "--setup-show --cov=ansys.pyensight.core --cov-report html:coverage-html --cov-report term --cov-config=.coveragerc --capture=tee-sys --tb=native -p no:warnings"
 markers =[
     "integration:Run integration tests",
     "smoke:Run the smoke tests",

--- a/src/ansys/pyensight/core/dockerlauncher.py
+++ b/src/ansys/pyensight/core/dockerlauncher.py
@@ -193,7 +193,7 @@ class DockerLauncher(Launcher):
 
             self._docker_client = docker.from_env()
         except ModuleNotFoundError:
-            raise RuntimeError("The pyansys-docker module must be installed for DockerLauncher")
+            raise RuntimeError("The docker module must be installed for DockerLauncher")
         except Exception:
             raise RuntimeError("Cannot initialize Docker")
 
@@ -308,7 +308,7 @@ class DockerLauncher(Launcher):
         try:
             import docker
         except ModuleNotFoundError:  # pragma: no cover
-            raise RuntimeError("The pyansys-docker module must be installed for DockerLauncher")
+            raise RuntimeError("The docker module must be installed for DockerLauncher")
         except Exception:  # pragma: no cover
             raise RuntimeError("Cannot initialize Docker")
 

--- a/tests/unit_tests/test_dockerlauncher.py
+++ b/tests/unit_tests/test_dockerlauncher.py
@@ -94,7 +94,7 @@ def test_start(mocker, capsys, caplog, enshell_mock, tmpdir):
     dock.side_effect = ModuleNotFoundError
     with pytest.raises(RuntimeError) as exec_info:
         launcher = DockerLauncher(data_directory=".")
-    assert "The pyansys-docker module must be installed for DockerLauncher" in str(exec_info)
+    assert "The docker module must be installed for DockerLauncher" in str(exec_info)
     dock.side_effect = KeyError
     with pytest.raises(RuntimeError) as exec_info:
         launcher = DockerLauncher(data_directory=".")

--- a/tests/unit_tests/test_renderable.py
+++ b/tests/unit_tests/test_renderable.py
@@ -21,7 +21,7 @@ def test_browser(mocked_session, mocker):
     render._url = "http://ansys.com"
     web = mocker.patch.object(webbrowser, "open")
     render.browser()
-    web.called_once_with(render.url)
+    web.assert_called_once_with(render.url)
 
 
 def test_download(mocked_session, mocker):


### PR DESCRIPTION
The PR does three things:

1) Remove support to 3.8 and add support to 3.12
2) Remove the need for the pyansys-docker fork, now the docker module works (tests are passing!). The fork was having issues since the code contains calls to distutils, removed from 3.12
3) I started seeing vale errors against string like ":func:`attrinfo<ansys.api.pyensight.ens_annot.ENS_ANNOT.attrinfo>", where the code style check was complaining that after "E" a space was required. This is of course not an issue being this a reference to an area of our docs; so I modifed the .vale.ini configuration file to ignore :func:`` and :samp:`` blocks
