### PR TITLE
expose AVZ as in memory geometry

### DIFF
--- a/tests/example_tests/test_coverage_increase.py
+++ b/tests/example_tests/test_coverage_increase.py
@@ -60,6 +60,7 @@ def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
     session.jupyter_notebook = False
     assert session.sos is False
     session.load_example("waterbreak.ens", root=root)
+    session.geometry("avz")
     core = session.ensight.objs.core
     core.PARTS.set_attr("COLORBYPALETTE", "alpha1")
     export = session.ensight.utils.export


### PR DESCRIPTION
As requested in the pyensight requests doc, this PR exposes the AVZ format through the geometry() interface.

In a first attempt I wanted to add a gRPC message, and an ad-hoc implementation, to get directly the AVZ file in memory. However I have found that EnSight calls an extension, which calls an in-house "external" tool, that generates a csf file and converts it to a physical AVZ file, so we have no direct way of generating an in-memory AVZ file. At this point I decided to create just a wrapper around the savegeom ensight interface to generate the file in a temporary location, read it and provide it in memory. Not ideal for large datasets, but it works.

We can of course discuss about creating an in-memory implementation of the CSF-AVZ exporter