### PR TITLE
add support for downloading files from example-data pyansys repo

### DIFF
--- a/tests/example_tests/test_coverage_increase.py
+++ b/tests/example_tests/test_coverage_increase.py
@@ -242,3 +242,6 @@ def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
     if not use_local:
         launcher.enshell_log_contents()
     assert session.ensight.objs.core.PARTS[0] != session.ensight.objs.core.PARTS[1]
+    cas_file = session.download_pyansys_example("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
+    dat_file = session.download_pyansys_example("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
+    session.load_data(cas_file, result_file=dat_file)


### PR DESCRIPTION
In the context of the Ansys lab deployment, has been requested an API to download files from the ansys/example-data public repo, where all the other teams are storing files to be downloaded during the examples tutorials.

Since this is conceptually similar to what we are doing in load_example, I have split portion of the latter to create "download_pyansys_example" and use it in load_example.

download_pyansys_example will use by default the github location, while load_example will override it with our s3 bucket, and since it will download session files it still has got the code to deal with the session file loading.

In the docstrings I have provided an example, which I also included in one of the docker github tests

in ansys/example-data we haven't got yet "ensight" examples, but we can already take advantage of the many fluent/mechanical examples that are available