### PR TITLE
Add Session API to check EnSight version

### DIFF
--- a/src/ansys/pyensight/core/utils/export.py
+++ b/src/ansys/pyensight/core/utils/export.py
@@ -565,6 +565,7 @@ class Export:
                 delta_timestep=delta_timestep,
             )
         else:
+            self._ensight._session.ensight_version_check("2024 R2")
             cmd = f"ensight.utils.export._geometry_remote('{format}', {starting_timestep}, {frames}, {delta_timestep})"
             raw_data_list = self._ensight._session.cmd(cmd)
         if raw_data_list:

--- a/src/ansys/pyensight/core/utils/parts.py
+++ b/src/ansys/pyensight/core/utils/parts.py
@@ -402,6 +402,11 @@ class Parts:
         self, particle_trace_part: Union[str, int, "ENS_PART_PARTICLE_TRACE"]
     ) -> "ENS_PART_PARTICLE_TRACE":
         """Private utility to cure an input particle trace part and convert it to an ``ENS_PART`"""
+
+        # the add_emitter* functions were added in 2024 R2
+        if not isinstance(self.ensight, ModuleType):
+            self.ensight._session.ensight_version_check("2024 R2")
+
         _particle_trace_part: "ENS_PART_PARTICLE_TRACE"
         if isinstance(particle_trace_part, (str, int)):
             temp = self.ensight.objs.core.PARTS[particle_trace_part]
@@ -418,6 +423,11 @@ class Parts:
         source_parts: Optional[List[Union[str, int, "ENS_PART"]]] = None,
     ) -> Tuple[str, List["ENS_PART"]]:
         """Private utility to set the direction if not provided, and to cure the list of source parts."""
+
+        # the create_particle* functions were added in 2024 R2
+        if not isinstance(self.ensight, ModuleType):
+            self.ensight._session.ensight_version_check("2024 R2")
+
         if not direction:
             direction = self.PT_POS_TIME
         if source_parts:

--- a/tests/example_tests/test_coverage_increase.py
+++ b/tests/example_tests/test_coverage_increase.py
@@ -245,3 +245,11 @@ def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
     cas_file = session.download_pyansys_example("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
     dat_file = session.download_pyansys_example("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
     session.load_data(cas_file, result_file=dat_file)
+    #
+    assert session.ensight_version_check("2021 R1")
+    assert session.ensight_version_check("211")
+    try:
+        session.ensight_version_check("2100 R2")
+        assert False
+    except Exception:
+        pass


### PR DESCRIPTION
Add a call on the Session object to make sure the EnSight version is at least some target.