### PR TITLE
Move the net_force tool from EnSight to PyEnSight

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
     "importlib-metadata>=4.0; python_version<='3.8'",
-    "ansys-api-pyensight==0.3.4",
+    "ansys-api-pyensight==0.3.6",
     "requests>=2.28.2",
     "docker>=6.1.0",
     "urllib3<2",

--- a/src/ansys/pyensight/core/utils/parts.py
+++ b/src/ansys/pyensight/core/utils/parts.py
@@ -1043,3 +1043,163 @@ class Parts:
             num_points=num_points,
         )
         return self._add_emitters_to_particle_trace_part(particle_trace_part, new_emitters)
+
+    ##############################################
+    #
+    #  select parts in the list, or if not a list
+    #    select the ensight.objs.ENS_PART
+    def select_parts(self, p_list, rec_flag=1):
+        """
+        Select the parts string, or int, or ensight.objs.ENS_PART, or list
+        and record the selection (by default) honoring the
+          EnSight preference to record command language by part id or by name
+
+        Parameters
+        ----------
+        p_list:
+        1. A list of ENS_PART objects OR
+        2. A list of int part ids OR
+        3. A list of strings
+            a. each string is an ID
+            b. each string is exact match for a part name OR
+        4. A single ENS_PART object OR
+        5. A single string
+            a. that is a part id OR
+            b. that exactly matches a part name
+
+        rec_flag - record the selection
+            1 = record the selection (default)
+            0 = don't record the selection
+
+        Action: creates list of part objects (as of 24.1)
+                and selects the parts, and records the
+                selection by default
+
+        Return: list of part objects selected (as of 24.1)
+                or [ ] if error.
+
+
+        NOTE: If you do not want a measured part in your
+                selection, then don't include it in the list
+                e.g. if
+                core.PARTS[0].PARTTYPE == ensight.objs.enums.PART_DISCRETE_PARTICLE == 3
+                then it is a measured part
+        """
+        #
+        pobj_list = self.get_part_id_obj_name(p_list, "obj")
+
+        if len(pobj_list) == 0:
+            print("Error, select_parts: part list is empty ")
+            return []
+        else:
+            # This was formerly used to record command lang 10.1.6(c)
+            #  using part ids:
+            #  ensight.part.select_begin(pid_list,record=1)
+            # Now records selection, honoring the the preference
+            #   part selection of by part id or by name (2024R1)
+            self.ensight.objs.core.selection(self.ensight.objs.ENS_PART).addchild(
+                pobj_list, replace=1, record=rec_flag
+            )
+            # This is essential to synchronize cmd lang with the GUI, C++
+            self.ensight.part.get_mainpartlist_select()
+
+        return pobj_list
+
+    def get_part_id_obj_name(self, plist=None, ret_flag="id"):
+        """
+        input a part or a list of parts and return an id, object, or name
+        or a list of ids, objects, or names.
+
+        Parameters
+        ----------
+        p_list:
+        1. A list of ENS_PART objects
+        OR
+        2. A list of int part ids
+        OR
+        3. A list of strings
+            a. each string is an ID
+            b. each string is exact match for a part name
+        OR
+        4. A single ENS_PART object
+        OR
+        5. A single string
+            a. that is a part id OR
+            b. that exactly matches the part DESCRIPTION
+        OR
+        6. a single int that is a part id
+
+        ret_flag - a string that determines what is returned
+
+        Return:
+        - a list as follows
+        A. ret_flag contains "id" -   returns a list of ids (default)
+        B. ret_flag contains "name" - returns a list of part names
+        C. ret_flag contains "obj"  - returns a list of ENS_PARTs
+        or [ ] if error.
+        """
+        if not plist:
+            plist = self.ensight.objs.core.PARTS
+        pobj_list = []
+        #
+        #  Basically figure out what plist is, then convert it to a list of ENS_PARTs
+        #
+        if (
+            isinstance(plist, self.ensight.objs.ENS_PART)
+            or isinstance(plist, int)
+            or isinstance(plist, str)
+        ):
+            p_list = [plist]
+        elif isinstance(plist, list) or isinstance(plist, self.ensight.objs.ensobjlist):
+            p_list = plist
+        else:
+            print("Unknown type of input var plist {}".format(type(plist)))
+            return []
+        #
+        #  p_list must now be a list
+        #
+        if len(p_list) > 0:
+            if isinstance(
+                p_list[0], self.ensight.objs.ENS_PART
+            ):  # list of objects assumed consistent
+                for prt in p_list:
+                    pobj_list.append(prt)
+            elif isinstance(p_list[0], int):  # list of ints must be part ids
+                for pid in p_list:
+                    d = {self.ensight.objs.enums.PARTNUMBER: pid}
+                    pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS, d)
+                    for prt in pobjs:
+                        pobj_list.append(prt)
+            elif isinstance(p_list[0], str):
+                if not p_list[0].isdigit():
+                    for pname in p_list:
+                        d = {self.ensight.objs.enums.DESCRIPTION: pname}
+                        pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS, d)
+                        for prt in pobjs:
+                            pobj_list.append(prt)
+                else:  # digits, must be a string list of part ids?
+                    for pid_str in p_list:
+                        d = {self.ensight.objs.enums.PARTNUMBER: int(pid_str)}
+                        pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS, d)
+                        for prt in pobjs:
+                            pobj_list.append(prt)
+            else:
+                print("First member is neither ENS_PART, int, nor string")
+                print("{} type= {}".format(p_list[0], type(p_list[0])))
+                print("aborting")
+                pobj_list = []
+        else:  # zero length list
+            print("Zero length list")
+            pobj_list = []
+        ret_val = []
+        if pobj_list:
+            for pobj in pobj_list:
+                if ret_flag.lower().find("name") >= 0:
+                    ret_val.append(pobj.DESCRIPTION)
+                elif ret_flag.lower().find("obj") >= 0:
+                    ret_val.append(pobj)
+                else:
+                    ret_val.append(pobj.PARTNUMBER)
+        else:
+            ret_val = []
+        return ret_val

--- a/src/ansys/pyensight/core/utils/variables.py
+++ b/src/ansys/pyensight/core/utils/variables.py
@@ -3,44 +3,74 @@
 This module provides simplified interface to compute specific variables via PyEnSight
 
 """
-import numpy as np
-import os
 import math
-from typing import TYPE_CHECKING, Union
+import os
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+from ansys.pyensight.core.utils.parts import convert_variable
+import numpy as np
 
 try:
     import ensight
-    from ensight.objs import ens_emitterobj, ensobjlist  # type: ignore
 except ImportError:
-    from ansys.api.pyensight.ens_emitterobj import ens_emitterobj
-    from ansys.pyensight.core.listobj import ensobjlist
+    pass
 
 if TYPE_CHECKING:
-    from ansys.api.pyensight.ens_var import ENS_VAR
     from ansys.api.pyensight import ensight_api
+    from ansys.api.pyensight.ens_part import ENS_PART
+    from ansys.api.pyensight.ens_var import ENS_VAR
 
-#
-#  finds float value vector magnitude
-#
-def vec_mag(inval):
+"""
+Compute the vector magnitude of the input vector
+
+Parameters
+----------
+inval: list
+    the vector components
+
+Returns
+-------
+float
+    the value of the vector magnitude. 0.0 if the vector is not a 3D vector
+
+"""
+
+
+def vec_mag(inval: List[float]) -> float:
     if len(inval) == 3:
-        vm = math.sqrt(inval[0]*inval[0] + inval[1]*inval[1] + inval[2]*inval[2])
+        vm = math.sqrt(inval[0] * inval[0] + inval[1] * inval[1] + inval[2] * inval[2])
     else:
         vm = 0.0
     return vm
 
+
 class Variables:
-    
+    """Controls the variables in the current EnSight ``Session`` instance."""
+
     def __init__(self, ensight: Union["ensight_api.ensight", "ensight"]):
         self.ensight = ensight
 
-#  Checks for the existence of var_name
-#   in the list of variables
-#
-#   FIX ME for many variables speed up!
-#
-    def _check_for_var_elem(self, var_name, pobj_list):
-        vlist = self.ensight.core.VARIABLES.find(var_name)
+    def _check_for_var_elem(
+        self, var_name: str, pobj_list: List["ENS_PART"]
+    ) -> Optional["ENS_VAR"]:
+        """
+        Check for the existence of a variable whose name is the input
+        var_name in the list of available variables. Check also if
+        the variable is defined in the input part object list
+
+        Parameters
+        ----------
+        var_name: str
+            the variable name to look for
+        pobj_list: list
+            the list of parts to see if the variable is defined on them
+
+        Returns
+        -------
+        ENS_VAR
+            the variable found if defined on all the input parts, None otherwise
+        """
+        vlist = self.ensight.objs.core.VARIABLES.find(var_name)
         if len(vlist) > 0:
             var = vlist[0]
             #  Check to see that selected parts are all
@@ -51,122 +81,177 @@ class Variables:
                     return None
             return var
         return None
-    
-#
-# IN: var_obj
-# OUT: calcs elemental from nodal variable and 
-#        returns list containing var object or empty list if err.
-#        Does nothing and returns input var name
-#        if already elemental.
-#
-#   elemental_var_list = move_var_to_elem( original_part_selection_list, shear_var_list[0])
-#
-#   Return a list containing the variable object or [ ] if failure 
-#
-    def _move_var_to_elem(self, pobj_list, var_obj):
+
+    def _move_var_to_elem(
+        self, pobj_list: List["ENS_PART"], var_obj: "ENS_VAR"
+    ) -> Optional[List["ENS_VAR"]]:
+        """
+        Check the input variable to see if it is an elemental variable.
+        If not, compute the equivalent Nodal variable via the NodeToElem
+        EnSight calculator function.
+
+        Parameters
+        ----------
+        pobj_list: list
+            the list of part objects to compute eventually the variable on
+        var_obj: ENS_VAR
+            the variable object to check
+
+        Returns
+        -------
+        list
+            A list containing either the original variable if already elemental,
+            or the computed nodal equivalent variable
+        """
         # get the last created var obj to use as a test to see if a new one is created
-        last_var_obj = max(self.ensight.core.VARIABLES)
+        last_var_obj = max(self.ensight.objs.core.VARIABLES)
         #
         var_name = var_obj.DESCRIPTION
         calc_var_name = ""
         if self.ensight.objs.enums.ENS_VAR_ELEM != var_obj.LOCATION:
             calc_var_name = "_E"
-            ret_val = self._check_for_var_elem(var_name+calc_var_name, pobj_list)
-            if ret_val == None:
+            ret_val = self._check_for_var_elem(var_name + calc_var_name, pobj_list)
+            if not ret_val:
                 print("Calculating elemental variable: {} {}".format(var_name, calc_var_name))
-                self.ensight.utils.parts.select_parts(pobj_list) 
-                calc_string = "(plist," + var_name + ')'
+                self.ensight.utils.parts.select_parts(pobj_list)
+                calc_string = "(plist," + var_name + ")"
                 per_node_var = var_name + calc_var_name + " = NodeToElem"
                 temp_string = per_node_var + calc_string
-                if 0 != self._calc_var(pobj_list, temp_string):
-                    self.ensight.int_message("Failed to calculate elemental variable",1)
-                    return []
+                if not self._calc_var(pobj_list, temp_string):
+                    raise RuntimeError("Failed to calculate elemental variable")
             else:
-                print("Using elemental variable that already exists: {}".format(ret_val.DESCRIPTION))
+                print(
+                    "Using elemental variable that already exists: {}".format(ret_val.DESCRIPTION)
+                )
                 return [ret_val]
 
         new_var_obj = max(self.ensight.objs.core.VARIABLES)
-        if new_var_obj != last_var_obj: # a new, elemental one was created!
+        if new_var_obj != last_var_obj:  # a new, elemental one was created!
             return [new_var_obj]
-        else: # return the input value as a new one wasn't created
+        else:  # return the input value as a new one wasn't created
             return [var_obj]
-        
-    #
-#  Calculates a variable
-#   using calc_string in ensight
-#
-#  Returns 0 if successful
-#         non-zero if fail
-#
-    def _calc_var(self, pobj_list=[],calc_string=""):
+
+    def _calc_var(
+        self, pobj_list: Optional[List["ENS_PART"]] = None, calc_string: Optional[str] = None
+    ) -> bool:
+        """
+        Computes a variable using the input calculator function on
+        the input part object list
+
+        Parameters
+        ----------
+        pobj_list: list
+            the list of part objects to compute the variable on
+        calc_string: str
+            the calculator function to compute
+
+        Returns
+        -------
+        bool
+            True if the computation was successful
+        """
         err = -1
-        if len(calc_string) > 0 and len(pobj_list)>0:
+        if not pobj_list or not calc_string:
+            return False
+        if len(calc_string) > 0 and len(pobj_list) > 0:
             self.ensight.utils.parts.select_parts(pobj_list)
-            err = self.ensight.variables.evaluate(calc_string) #,record=1)
+            err = self.ensight.variables.evaluate(calc_string)  # ,record=1)
             if err != 0:
                 err_string = "Error calculating " + calc_string
-                self.ensight.int_message(err_string,1)
-        return err
+                raise RuntimeError(err_string)
+        return err == 0
 
-#
-#
-# IN:
-#  part object list - A list of ENS_PARTs
-#  var_object -     Must be an elemental variable
-#  shear_or_force_flag = "Shear stress" or "Shear force" depending on the shear variable
-#                        This is obtained from the gui params['shear_vartype']
-#  frame_index - if > 0 then use this frame to calculate cylindrical components in this
-#                        frame
-#
-# OUT:
-#
-#    Creates (or recreates) several intermediate vars:
-#
-#    ENS_Force_Norm
-#
-#    depending on if the shear variable is Force or Stress:
-#    ENS_Force_Dot_prod_Flu_shear_<Force or Stress>_Norm 
-#    ENS_Force_NomalShear<Force or Stress>
-#
-#    ENS_Force_TangentialShear<Force or Stress>
-#
-#    ENS_Force_TangentialShear<Force or Stress>_X
-#    ENS_Force_TangentialShear<Force or Stress>_Y
-#    ENS_Force_TangentialShear<Force or Stress>_Z
-#
-#    if the variable is shear stress
-#       ENS_Force_ElementArea
-#
-#    And finally the shear force components:
-#     ENS_Force_TangentialShearForce_X
-#     ENS_Force_TangentialShearForce_Y
-#     ENS_Force_TangentialShearForce_Z
-#
-#    Now, new in 10.1.6(c), RTZ if more than one frame and chosen frame index exists
-#     ENS_Force_Tan_ShearForce (which is a vector composed of the above components)
-#     ENS_Force_Tan_ShearForce_cyl (which is cylindrical resolved in the frame index coordinate sys)
-#     and the components of the cylindrical vector:
-#      ENS_Force_Tan_ShearForce_R - Radial component
-#      ENS_Force_Tan_ShearForce_T - Theta (angular) component
-#      ENS_Force_Tan_ShearForce_A - Axial (frame index Z) component
-#
-#   WARNING: Each time you call this function, it
-#     overwrites all these EnSight variables.
-#
-#   WARNING: These variable names are the same
-#      as the 10.0 Pressure Force Python Tool
-#
-    def _shear_force_xyz_rtz(self, pobj_list, shear_var_obj, shear_or_force_flag = "Shear stress", frame_index = 0):
-        #  
+    def _shear_force_xyz_rtz(
+        self,
+        pobj_list: Optional[List[Union[str, int, "ENS_PART"]]] = None,
+        shear_var_obj: Optional[Union[str, int, "ENS_VAR"]] = None,
+        shear_or_force_flag: Optional[str] = "Shear stress",
+        frame_index: Optional[int] = 0,
+    ) -> bool:
+        """
+        Compute the shear force in the cartesian and cylindrical space.
+        It creates (or recreates) several intermediate vars:
+
+        - ENS_Force_Norm
+
+        depending on if the shear variable is Force or Stress:
+
+        - ENS_Force_Dot_prod_Flu_shear_<Force or Stress>_Norm
+        - ENS_Force_NomalShear<Force or Stress>
+
+        - ENS_Force_TangentialShear<Force or Stress>
+
+        - ENS_Force_TangentialShear<Force or Stress>_X
+        - ENS_Force_TangentialShear<Force or Stress>_Y
+        - ENS_Force_TangentialShear<Force or Stress>_Z
+
+        if the variable is shear stress
+        - ENS_Force_ElementArea
+
+        And finally the shear force components:
+        - ENS_Force_TangentialShearForce_X
+        - ENS_Force_TangentialShearForce_Y
+        - ENS_Force_TangentialShearForce_Z
+
+        If there is more than one frame and the input frame exists, also the
+        cylindrical components are computed, whose names will be:
+
+        - ENS_Force_Tan_ShearForce (which is a vector composed of the above components)
+        - ENS_Force_Tan_ShearForce_cyl (which is cylindrical resolved in the frame index coordinate sys)
+        and the components of the cylindrical vector:
+        - ENS_Force_Tan_ShearForce_R - Radial component
+        - ENS_Force_Tan_ShearForce_T - Theta (angular) component
+        - ENS_Force_Tan_ShearForce_A - Axial (frame index Z) component
+
+        WARNING: Each time you call this function, it
+        overwrites all these EnSight variables.
+
+        WARNING: These variable names are the same
+        as the 10.0 Pressure Force Python Tool
+
+        Parameters
+        ----------
+        pobj_list: list
+            The list of part objects to compute the forces on. It can either be a list of names
+            a list of IDs (integers or strings) or directly a list of ENS_PART objects
+        var_object: ENS_VAR
+            The variable object to use as shear variable. If nodal, it will be converted
+            into an elemental variable
+        shear_or_force_flag: str
+            It can either be "Shear stress" or "Shear force" to indicate the kind of shear variable
+            supplied
+        frame_index: int
+            The eventual frame index on which to compute the cylindrical components of the forces
+
+        Returns
+        -------
+        bool
+            True if the computation was successful
+
+        """
+        if not frame_index:
+            frame_index = 0
+        #
         # This pobj_list should contain only 2D parts
         #
-        if len(pobj_list) < 1:
-            self.ensight.int_message("Error, no part provided",1)
-            return False
+
+        # tricks for mypy
+        varid = convert_variable(self.ensight, shear_var_obj)
+        _shear_var_obj: "ENS_VAR"
+        values = self.ensight.objs.core.VARIABLES.find(varid, "ID")
+        ensvar_values: List["ENS_VAR"]
+        ensvar_values = [v for v in values]
+        _shear_var_obj = ensvar_values[0]
+
+        if not pobj_list:
+            raise RuntimeError("Error, no part provided")
         #
         # select all parts in list
         #
-        self.ensight.utils.parts.select_parts(pobj_list)
+        _pobj_list: List["ENS_PART"]
+        _pobj_list = self.ensight.utils.parts.select_parts(pobj_list)
+        if not _pobj_list:
+            return False
         #
         # can be using shear force or shear stress
         #
@@ -174,164 +259,216 @@ class Variables:
             stemp_string = "Stress"
         else:
             stemp_string = "Force"
-        # create a surface normal vector variable using the 
+        # create a surface normal vector variable using the
         # "Normal" function in the variable calculator.
         #
         temp_string = "ENS_Force_Norm = Normal(plist)"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        if not self._calc_var(_pobj_list, temp_string):
             return False
         #
         # makes a new elem var if input var is nodal
         #
         #
-        if shear_var_obj.LOCATION == self.ensight.objs.enums.ENS_VAR_ELEM:
-            shear_var_name = shear_var_obj.DESCRIPTION
+        new_shear_var_obj: "ENS_VAR"
+        shear_var_name: str
+        if _shear_var_obj.LOCATION != self.ensight.objs.enums.ENS_VAR_ELEM:
+            # tricks for mypy
+            values = self._move_var_to_elem(_pobj_list, _shear_var_obj)
+            ensvar_values = [v for v in values]
+            new_shear_var_obj = ensvar_values[0]
+            shear_var_name = new_shear_var_obj.DESCRIPTION
         else:
-            err_string = "Error shear_force_xyz_rtz: variable {} is not an elemental variable".format(shear_var_obj.DESCRIPTION)
-            self.ensight.int_message(err_string,1)
-            return False
-        
+            shear_var_name = _shear_var_obj.DESCRIPTION
+
         #
         # Compute the Dot product of the Vector Normal and the FluidShearVector
         #
-        temp_string = "ENS_Force_Dot_prod_Flu_shear_"+ stemp_string +"_Norm = DOT(" + shear_var_name + ",ENS_Force_Norm)"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        temp_string = (
+            "ENS_Force_Dot_prod_Flu_shear_"
+            + stemp_string
+            + "_Norm = DOT("
+            + shear_var_name
+            + ",ENS_Force_Norm)"
+        )
+        if not self._calc_var(_pobj_list, temp_string):
             return False
-        
-        # multiplying this DOT product by the surface normal vector produces 
+
+        # multiplying this DOT product by the surface normal vector produces
         # the normal component of the shear stress vector.
         #
-        temp_string = "ENS_Force_NomalShear"+ stemp_string +" = ENS_Force_Dot_prod_Flu_shear_"+ stemp_string +"_Norm*ENS_Force_Norm"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        temp_string = (
+            "ENS_Force_NomalShear"
+            + stemp_string
+            + " = ENS_Force_Dot_prod_Flu_shear_"
+            + stemp_string
+            + "_Norm*ENS_Force_Norm"
+        )
+        if not self._calc_var(_pobj_list, temp_string):
             return False
         #
-        # The tangential component is now computed by subtracting this normal 
-        # component from the shear stress vector, or Vt = V - Vn, 
-        # where V represents the shear stress vector. 
+        # The tangential component is now computed by subtracting this normal
+        # component from the shear stress vector, or Vt = V - Vn,
+        # where V represents the shear stress vector.
         #
-        temp_string = "ENS_Force_TangentialShear" + stemp_string + " = " + shear_var_name + "-ENS_Force_NomalShear"+ stemp_string
-        if 0 != self._calc_var(pobj_list,temp_string):
+        temp_string = (
+            "ENS_Force_TangentialShear"
+            + stemp_string
+            + " = "
+            + shear_var_name
+            + "-ENS_Force_NomalShear"
+            + stemp_string
+        )
+        if not self._calc_var(_pobj_list, temp_string):
             return False
         #
-        # Decompose the TangentialShearStress Vector into its x, y, z component of 
+        # Decompose the TangentialShearStress Vector into its x, y, z component of
         # TangentialShearStress_X, TangentialShearStress_Y, and TangentialShearStress_Z
-        temp_string = "ENS_Force_TangentialShear"+ stemp_string +"_X = ENS_Force_TangentialShear"+ stemp_string +"[X]"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        temp_string = (
+            "ENS_Force_TangentialShear"
+            + stemp_string
+            + "_X = ENS_Force_TangentialShear"
+            + stemp_string
+            + "[X]"
+        )
+        if not self._calc_var(_pobj_list, temp_string):
             return False
-        
-        temp_string = "ENS_Force_TangentialShear"+ stemp_string +"_Y = ENS_Force_TangentialShear"+ stemp_string +"[Y]"
-        if 0 != self._calc_var(pobj_list,temp_string):
+
+        temp_string = (
+            "ENS_Force_TangentialShear"
+            + stemp_string
+            + "_Y = ENS_Force_TangentialShear"
+            + stemp_string
+            + "[Y]"
+        )
+        if not self._calc_var(_pobj_list, temp_string):
             return False
-        
-        temp_string = "ENS_Force_TangentialShear"+ stemp_string +"_Z = ENS_Force_TangentialShear"+ stemp_string +"[Z]"
-        if 0 != self._calc_var(pobj_list,temp_string):
+
+        temp_string = (
+            "ENS_Force_TangentialShear"
+            + stemp_string
+            + "_Z = ENS_Force_TangentialShear"
+            + stemp_string
+            + "[Z]"
+        )
+        if not self._calc_var(_pobj_list, temp_string):
             return False
-        
+
         #
         #
-        # Calculate the Tangential Shear stress forces by multiplying each of the 
+        # Calculate the Tangential Shear stress forces by multiplying each of the
         # Components of the Tangential Shear stress with Element Size scalar.
         if shear_or_force_flag == "Shear stress":
             #
             # Calculate the element area Scalar using the "EleSize function in the Variable Calculator
             #
             temp_string = "ENS_Force_ElementArea = EleSize(plist)"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-            
-            temp_string = "ENS_Force_Tan_ShearForce_X = ENS_Force_TangentialShear"+ stemp_string +"_X*ENS_Force_ElementArea"
-            if 0 != self._calc_var(pobj_list,temp_string):
+
+            temp_string = (
+                "ENS_Force_Tan_ShearForce_X = ENS_Force_TangentialShear"
+                + stemp_string
+                + "_X*ENS_Force_ElementArea"
+            )
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-            
-            temp_string = "ENS_Force_Tan_ShearForce_Y = ENS_Force_TangentialShear"+ stemp_string +"_Y*ENS_Force_ElementArea"
-            if 0 != self._calc_var(pobj_list,temp_string):
+
+            temp_string = (
+                "ENS_Force_Tan_ShearForce_Y = ENS_Force_TangentialShear"
+                + stemp_string
+                + "_Y*ENS_Force_ElementArea"
+            )
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-            
-            temp_string = "ENS_Force_Tan_ShearForce_Z = ENS_Force_TangentialShear"+ stemp_string +"_Z*ENS_Force_ElementArea"
-            if 0 != self._calc_var(pobj_list,temp_string):
+
+            temp_string = (
+                "ENS_Force_Tan_ShearForce_Z = ENS_Force_TangentialShear"
+                + stemp_string
+                + "_Z*ENS_Force_ElementArea"
+            )
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-            
+
         else:
-            temp_string = "ENS_Force_Tan_ShearForce_X = ENS_Force_TangentialShear"+ stemp_string +"_X"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            temp_string = (
+                "ENS_Force_Tan_ShearForce_X = ENS_Force_TangentialShear" + stemp_string + "_X"
+            )
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-        
-            temp_string = "ENS_Force_Tan_ShearForce_Y = ENS_Force_TangentialShear"+ stemp_string +"_Y"
-            if 0 != self._calc_var(pobj_list,temp_string):
+
+            temp_string = (
+                "ENS_Force_Tan_ShearForce_Y = ENS_Force_TangentialShear" + stemp_string + "_Y"
+            )
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-        
-            temp_string = "ENS_Force_Tan_ShearForce_Z = ENS_Force_TangentialShear"+ stemp_string +"_Z"
-            if 0 != self._calc_var(pobj_list,temp_string):
+
+            temp_string = (
+                "ENS_Force_Tan_ShearForce_Z = ENS_Force_TangentialShear" + stemp_string + "_Z"
+            )
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-        
+
         if frame_index > 0 and frame_index < len(self.ensight.objs.core.FRAMES):
             # remake the vector
             temp_string = "ENS_Force_Tan_ShearForce = MakeVect(plist, ENS_Force_Tan_ShearForce_X, ENS_Force_Tan_ShearForce_Y, ENS_Force_Tan_ShearForce_Z)"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-            
+
             # resolve it in cylindrical coords
-            temp_string = "ENS_Force_Tan_ShearForce_cyl = RectToCyl(plist,ENS_Force_Tan_ShearForce,"+str(frame_index)+")"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            temp_string = (
+                "ENS_Force_Tan_ShearForce_cyl = RectToCyl(plist,ENS_Force_Tan_ShearForce,"
+                + str(frame_index)
+                + ")"
+            )
+            if not self._calc_var(_pobj_list, temp_string):
                 return False
-            
+
             # Radial, theta , axial
             temp_string = "ENS_Force_Tan_ShearForce_R  = ENS_Force_Tan_ShearForce_cyl[X]"
-            if 0 != self._calc_var(pobj_list,temp_string):  # radial force
+            if not self._calc_var(_pobj_list, temp_string):  # radial force
                 return False
-        
+
             temp_string = "ENS_Force_Tan_ShearForce_T  = ENS_Force_Tan_ShearForce_cyl[Y]"
-            if 0 != self._calc_var(pobj_list,temp_string): # angular force
+            if not self._calc_var(_pobj_list, temp_string):  # angular force
                 return False
-        
+
             temp_string = "ENS_Force_Tan_ShearForce_A  = ENS_Force_Tan_ShearForce_cyl[Z]"
-            if 0 != self._calc_var(pobj_list,temp_string): # axial force        
+            if not self._calc_var(_pobj_list, temp_string):  # axial force
                 return False
         return True
 
-    #
-    #  Uses the stat moment calc function to sum the shear forces for this list of parts
-    #   resulting in a per part constant and a case constant as of 10.2.0(d) for each force component
-    #   IN:
-    #     pobj_list - A list of ENS_PART(s)
-    #
-    #     frame_index = If 0 then do not calc RTZ cylindrical net forces
-    #                 otherwise calculate the net forces in Radial, Theta, and Axial
-    #    
-    #    OUT
-    #    calculates the net shear force per part constant using all parts
-    #     in the list and creates three or six per part constants:
-    #      ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z
-    #
-    #    Now, new in 10.1.6(c), RTZ if more than one frame and chosen frame index exists
-    #     if frame_index > 0, then calc net force using the cylindrical forces in the
-    #     frame_index reference system adn in 10.2.0(d) three are per part constants
-    #
-    #       ENS_Force_Net_Tan_ShearForce_R - net shear force in the radial direction
-    #       ENS_Force_Net_Tan_ShearForce_T - net shear force in the angular (theta) direction
-    #       ENS_Force_Net_Tan_ShearForce_A - net shear force in the axial (frame index Z) direction
-    #
-    #    Returns:
-    #       if frame_index > 0 and frame exists then returns forces for each part in the list:
-    #          ( [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z,  ENS_Force_Net_Tan_ShearForce_R, ENS_Force_Net_Tan_ShearForce_T, ENS_Force_Net_Tan_ShearForce_A  ]  ,
-    #            [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z , ENS_Force_Net_Tan_ShearForce_R, ENS_Force_Net_Tan_ShearForce_T, ENS_Force_Net_Tan_ShearForce_A  ]  ,
-    #            [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z, ENS_Force_Net_Tan_ShearForce_R, ENS_Force_Net_Tan_ShearForce_T, ENS_Force_Net_Tan_ShearForce_A  ]  , ...)
-    #       else:
-    #          ( [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z , 0.0  , 0.0  , 0.0  ]  ,
-    #          ( [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z , 0.0  , 0.0  , 0.0  ]  ,
-    #          ( [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z , 0.0  , 0.0  , 0.0  ]  , ...)
-    #       ERROR:
-    #              [ ] empty list if error calculating vars or getting constant values
-    #
-    def _sum_shear_forces_xyz_rtz(self, pobj_list, frame_index = -1):
-        #  
+    def _sum_shear_forces_xyz_rtz(
+        self,
+        pobj_list: Optional[List[Union[str, int, "ENS_PART"]]] = None,
+        frame_index: Optional[int] = 0,
+    ) -> Optional[List[List[float]]]:
+        """
+        Compute the sum of the shear forces on the input part objects list
+        and on the eventual frame selected via the StatMoment calculator function in EnSight
+
+        Parameters
+        ----------
+        pobj_list: list
+            The list of part objects to compute the forces on. It can either be a list of names
+            a list of IDs (integers or strings) or directly a list of ENS_PART objects
+        frame_index: int
+            The eventual frame index on which to compute the cylindrical components of the forces
+
+        Returns
+        -------
+        list
+            The list of computed force values. These will be per part constant variables.
+            Three if only cartesian, six if also the cylindrical components were computed.
+        """
+        if not frame_index:
+            frame_index = 0
+        #
         # This pobj_list should contain only 2D parts
         #
         #
         fcn_name = "sum_shear_forces_xyz_rtz"
-        if len(pobj_list) < 1:
-            self.ensight.int_message("Error, no part provided",1)
-            return []
+        if not pobj_list:
+            raise RuntimeError("Error, no part provided")
         #
         # select all parts in list
         #
@@ -342,152 +479,207 @@ class Variables:
         #
         #
         temp_string = "ENS_Force_Net_Tan_ShearForce_X = StatMoment(plist,ENS_Force_Tan_ShearForce_X, 0, Compute_Per_part)"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        if not self._calc_var(pobj_list, temp_string):
             err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-            ensight.int_message(err_string,1)
-            return []
-        
+            raise RuntimeError(err_string)
+
         temp_string = "ENS_Force_Net_Tan_ShearForce_Y = StatMoment(plist,ENS_Force_Tan_ShearForce_Y, 0, Compute_Per_part)"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        if not self._calc_var(pobj_list, temp_string):
             err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-            self.ensight.int_message(err_string,1)
-            return []
-    
+            raise RuntimeError(err_string)
+
         temp_string = "ENS_Force_Net_Tan_ShearForce_Z = StatMoment(plist,ENS_Force_Tan_ShearForce_Z, 0, Compute_Per_part)"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        if not self._calc_var(pobj_list, temp_string):
             err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-            self.ensight.int_message(err_string,1)
-            return []
+            raise RuntimeError(err_string)
         #
         # get the 3 constant force values XYZ
         # 10.1.6(b) use ens_utils, 10.2.0(d) Now gets all the per part constants in a list
-        Fx = self.get_const_val("ENS_Force_Net_Tan_ShearForce_X",pobj_list)
-        Fy = self.get_const_val("ENS_Force_Net_Tan_ShearForce_Y",pobj_list)
-        Fz = self.get_const_val("ENS_Force_Net_Tan_ShearForce_Z",pobj_list)
+
+        # In this case we know that the value returned by get_const_val will be a List of floats,
+        # but mypy doesn't know about it. The next code just makes it happy
+        Fx: List[float] = []
+        Fy: List[float] = []
+        Fz: List[float] = []
+        val = self.get_const_val("ENS_Force_Net_Tan_ShearForce_X", pobj_list)
+        if not val:
+            return None
+        if val:
+            if isinstance(val, list):
+                for v in val:
+                    if not v:
+                        return None
+                    Fx.append(v)
+            else:
+                return None
+        val = self.get_const_val("ENS_Force_Net_Tan_ShearForce_Y", pobj_list)
+        if not val:
+            return None
+        if val:
+            if isinstance(val, list):
+                for v in val:
+                    if not v:
+                        return None
+                    Fy.append(v)
+            else:
+                return None
+        val = self.get_const_val("ENS_Force_Net_Tan_ShearForce_Z", pobj_list)
+        if not val:
+            return None
+        if val:
+            if isinstance(val, list):
+                for v in val:
+                    if not v:
+                        return None
+                    Fz.append(v)
+            else:
+                return None
         #
         # Calculate the Total Shear force X, Y, and Z , 10.2.0(d) now case constant variable
         #  Totals are a case constants. We don't do anything with these vars
         #   they are calc'd to give the user the totals.
         #
         temp_string = "ENS_Force_Total_Net_Tan_ShearForce_X = StatMoment(plist,ENS_Force_Tan_ShearForce_X, 0, Compute_Per_case)"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        if not self._calc_var(pobj_list, temp_string):
             err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-            self.ensight.int_message(err_string,1)
-            return []
-        
+            raise RuntimeError(err_string)
+
         temp_string = "ENS_Force_Total_Net_Tan_ShearForce_Y = StatMoment(plist,ENS_Force_Tan_ShearForce_Y, 0, Compute_Per_case)"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        if not self._calc_var(pobj_list, temp_string):
             err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-            self.ensight.int_message(err_string,1)
-            return []
-    
+            raise RuntimeError(err_string)
+
         temp_string = "ENS_Force_Total_Net_Tan_ShearForce_Z = StatMoment(plist,ENS_Force_Tan_ShearForce_Z, 0, Compute_Per_case)"
-        if 0 != self._calc_var(pobj_list,temp_string):
+        if not self._calc_var(pobj_list, temp_string):
             err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-            self.ensight.int_message(err_string,1)
-            return []
-        #
-        #   
-        #
+            raise RuntimeError(err_string)
+
         if frame_index > 0 and frame_index < len(self.ensight.objs.core.FRAMES):
             temp_string = "ENS_Force_Net_Tan_ShearForce_R = StatMoment(plist,ENS_Force_Tan_ShearForce_R,0, Compute_Per_part)"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            if not self._calc_var(pobj_list, temp_string):
                 err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-                self.ensight.int_message(err_string,1)
-                return []
-    
+                raise RuntimeError(err_string)
+
             temp_string = "ENS_Force_Net_Tan_ShearForce_T = StatMoment(plist,ENS_Force_Tan_ShearForce_T,0, Compute_Per_part)"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            if not self._calc_var(pobj_list, temp_string):
                 err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-                self.ensight.int_message(err_string,1)
-                return []
-    
+                raise RuntimeError(err_string)
+
             temp_string = "ENS_Force_Net_Tan_ShearForce_A = StatMoment(plist,ENS_Force_Tan_ShearForce_A,0, Compute_Per_part)"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            if not self._calc_var(pobj_list, temp_string):
                 err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-                self.ensight.int_message(err_string,1)
-                return []
+                raise RuntimeError(err_string)
             #
             # Totals
             #
             temp_string = "ENS_Force_Total_Net_Tan_ShearForce_R = StatMoment(plist,ENS_Force_Tan_ShearForce_R,0, Compute_Per_case)"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            if not self._calc_var(pobj_list, temp_string):
                 err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-                self.ensight.int_message(err_string,1)
-                return []
-    
+                raise RuntimeError(err_string)
+
             temp_string = "ENS_Force_Total_Net_Tan_ShearForce_T = StatMoment(plist,ENS_Force_Tan_ShearForce_T,0, Compute_Per_case)"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            if not self._calc_var(pobj_list, temp_string):
                 err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-                self.ensight.int_message(err_string,1)
-                return []
-    
+                raise RuntimeError(err_string)
+
             temp_string = "ENS_Force_Total_Net_Tan_ShearForce_A = StatMoment(plist,ENS_Force_Tan_ShearForce_A,0, Compute_Per_case)"
-            if 0 != self._calc_var(pobj_list,temp_string):
+            if not self._calc_var(pobj_list, temp_string):
                 err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
-                self.ensight.int_message(err_string,1)
-                return []
+                raise RuntimeError(err_string)
             #
             # get the 3 constant force values Radial, Theta, Axial
             # new use ens_utils 10.1.6(b)
-            Fr = self.get_const_val("ENS_Force_Net_Tan_ShearForce_R",pobj_list)
-            Ft = self.get_const_val("ENS_Force_Net_Tan_ShearForce_T",pobj_list)
-            Fa = self.get_const_val("ENS_Force_Net_Tan_ShearForce_A",pobj_list)
-            if Fr != None and Fa != None and Ft != None and Fx != None and Fy != None and Fz != None: 
+
+            # we know that the output of get_const_val will be a list of floats,
+            # buy mypy doesn't know it. So the next code is just to make it happy
+
+            Fr: List[float] = []
+            Ft: List[float] = []
+            Fa: List[float] = []
+            val = self.get_const_val("ENS_Force_Net_Tan_ShearForce_R", pobj_list)
+            if not val:
+                return None
+            if val:
+                if isinstance(val, list):
+                    for v in val:
+                        if not v:
+                            return None
+                        Fr.append(v)
+                else:
+                    return None
+            val = self.get_const_val("ENS_Force_Net_Tan_ShearForce_T", pobj_list)
+            if not val:
+                return None
+            if val:
+                if isinstance(val, list):
+                    for v in val:
+                        if not v:
+                            return None
+                        Ft.append(v)
+                else:
+                    return None
+            val = self.get_const_val("ENS_Force_Net_Tan_ShearForce_A", pobj_list)
+            if not val:
+                return None
+            if val:
+                if isinstance(val, list):
+                    for v in val:
+                        if not v:
+                            return None
+                        Fa.append(v)
+                else:
+                    return None
+            if all([Fr, Fa, Ft, Fx, Fy, Fz]):
                 ret_val = []
                 for ii in range(len(pobj_list)):
-                    ret_val.append([Fx[ii],Fy[ii],Fz[ii],Fr[ii],Ft[ii],Fa[ii]])
-                return ret_val            
-            else:
-                self.ensight.int_message("Error getting ENS_Force_Net_Tan_ShearForce_R, T and/or A",1)
-                return []
-        else: # Only one frame or user picked frame 0 (None) for cylindrical frame calc
-            if  Fx != None and Fy != None and Fz != None:
-                ret_val = []
-                for ii in range(len(pobj_list)):
-                    ret_val.append([Fx[ii],Fy[ii],Fz[ii],0.0,0.0,0.0])
+                    ret_val.append([Fx[ii], Fy[ii], Fz[ii], Fr[ii], Ft[ii], Fa[ii]])
                 return ret_val
             else:
-                self.ensight.int_message("Error getting Fx, Fy, and/or Fz Shear Net force per part constant values",1)
-                return []            
+                raise RuntimeError("Error getting ENS_Force_Net_Tan_ShearForce_R, T and/or A")
+        else:  # Only one frame or user picked frame 0 (None) for cylindrical frame calc
+            if all([Fx, Fy, Fz]):
+                ret_val = []
+                for ii in range(len(pobj_list)):
+                    ret_val.append([Fx[ii], Fy[ii], Fz[ii], 0.0, 0.0, 0.0])
+                return ret_val
+            else:
+                raise RuntimeError(
+                    "Error getting Fx, Fy, and/or Fz Shear Net force per part constant values"
+                )
 
-    
-    
-    #
-    # Returns constant or (new in 10.2) per part constant var objects
-    #
-    def get_const_vars(self, var_type=None):
+    def get_const_vars(self, var_type: Optional[int] = None) -> List["ENS_VAR"]:
         """
         Get all constant OR per part constant variables
 
         Parameters
         ----------
-        var_type - enums.ENS_VAR_CONSTANT (default)
-            or     enums.ENS_VAR_CONSTANT_PER_PART (new in 10.2)
+        var_type: int
+            enums.ENS_VAR_CONSTANT (default) if not provided
+            or enums.ENS_VAR_CONSTANT_PER_PART
 
-        Return
-        List containing ENS_VAR objects
-
+        Returns
+        -------
+        list
+            List containing ENS_VAR objects
         """
         if not var_type:
             var_type = self.ensight.objs.enums.ENS_VAR_CONSTANT
-        d = {self.ensight.objs.enums.VARTYPE: var_type}
-        return(self.ensight.objs.core.find_objs(self.ensight.objs.core.VARIABLES,filter=d))
-    #
-    # Returns list constant or (new in 10.2) per part constant var names
-    #
-    def get_const_var_names(self, v_type=None):
+        return [v for v in self.ensight.objs.core.VARIABLES if v.VARTYPE == var_type]
+
+    def get_const_var_names(self, v_type: Optional[int] = None) -> List[str]:
         """
-        Get string names of all constant OR per part constant variables 
+        Get the names of all constant OR per part constant variables
 
         Parameters
         ----------
-        v_type   - enums.ENS_VAR_CONSTANT (default)
-            or     enums.ENS_VAR_CONSTANT_PER_PART (new in 10.2)
+        v_type: int
+            enums.ENS_VAR_CONSTANT (default) if not provided
+            or enums.ENS_VAR_CONSTANT_PER_PART
 
-        Return
-        List containing names of constants
-
+        Returns
+        -------
+        list
+            List containing names of constants
         """
         if not v_type:
             v_type = self.ensight.objs.enums.ENS_VAR_CONSTANT
@@ -495,134 +687,38 @@ class Variables:
         vars = self.get_const_vars(var_type=v_type)
         for var in vars:
             name_list.append(var.DESCRIPTION)
-        return(name_list)
+        return name_list
 
-    def get_part_id_obj_name(self, plist=None, ret_flag="id"):
+    def get_const_val(
+        self,
+        cname: str,
+        part_list: Optional[List[Union[str, int, "ENS_PART"]]] = None,
+        undef_none=False,
+    ) -> Optional[Union[Optional[float], Optional[List[Optional[float]]]]]:
         """
-        input a part or a list of parts and return an id, object, or name
-          or a list of ids, objects, or names.
-        
+        Return a float value of a variable Case constant at the current timestep,
+        or return a list of values one for each part if a per part constant.
+
         Parameters
         ----------
-        p_list:
-          1. A list of ENS_PART objects 
-          OR
-          2. A list of int part ids 
-          OR
-          3. A list of strings
-             a. each string is an ID
-             b. each string is exact match for a part name 
-          OR
-          4. A single ENS_PART object 
-          OR
-          5. A single string
-             a. that is a part id OR
-             b. that extactly matches the part DESCRIPTION
-          OR
-          6. a single int that is a part id
-          
-        ret_flag - a string that determines what is returned
-        
-        Return: 
-          - a list as follows
-          A. ret_flag contains "id" -   returns a list of ids (default)
-          B. ret_flag contains "name" - returns a list of part names
-          C. ret_flag contains "obj"  - returns a list of ENS_PARTs      
-          or [ ] if error.    
-        """
-        if not plist:
-            plist = self.ensight.objs.core.PARTS
-        pobj_list = []
-        #
-        #  Basically figure out what plist is, then convert it to a list of ENS_PARTs
-        #
-        if isinstance(plist, self.ensight.objs.ENS_PART) or  isinstance(plist,int) or isinstance(plist,str):
-            p_list = [plist]
-        elif  isinstance(plist, list) or isinstance(plist, self.ensight.objs.ensobjlist):
-            p_list = plist
-        else:
-            print("Unknown type of input var plist {}".format(type(plist)))
-            return []
-        #
-        #  p_list must now be a list
-        #
-        if len(p_list) > 0:
-            if isinstance(p_list[0], self.ensight.objs.ENS_PART): # list of objects assumed consistent
-                for prt in p_list:
-                    pobj_list.append(prt)
-            elif isinstance(p_list[0],int): # list of ints must be part ids
-                for pid in p_list:
-                    d = {self.ensight.objs.enums.PARTNUMBER:pid}
-                    pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS,d)
-                    for prt in pobjs:
-                        pobj_list.append(prt)
-            elif isinstance(p_list[0],str):
-                if p_list[0].isdigit() == False:
-                    for pname in p_list:
-                        d = {self.ensight.objs.enums.DESCRIPTION:pname}
-                        pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS,d)
-                        for prt in pobjs:
-                            pobj_list.append(prt)
-                else: # digits, must be a string list of part ids? 
-                    for pid_str in p_list:
-                        d =  {self.ensight.objs.enums.PARTNUMBER:int(pid_str)}
-                        pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS,d)
-                        for prt in pobjs:
-                            pobj_list.append(prt)
-            else:
-                print("First member is neither ENS_PART, int, nor string")
-                print("{} type= {}".format(p_list[0],type(p_list[0])))
-                print("aborting")
-                pobj_list = []
-        else: # zero length list
-            print("Zero length list")
-            pobj_list = []
-        ret_val = []
-        if pobj_list:
-            for pobj in pobj_list:
-                if ret_flag.lower().find('name') >=0:
-                    ret_val.append(pobj.DESCRIPTION)
-                elif ret_flag.lower().find('obj') >=0:
-                    ret_val.append(pobj)
-                else:
-                    ret_val.append(pobj.PARTNUMBER)
-        else:
-            ret_val = []
-        return ret_val
+        cname: str
+            the text name of the constant or ENS_VAR object
 
-    def get_const_val(self, cname, part_list=None, undef_none=False):
-        """
-          Return a float value of a variable Case constant at the current timestep,
-             or return a list of values one for each part if a per part constant.
-             
-          Parameters
-          ----------
-          cname - the text name of the constant or ENS_VAR object 
-    
-          part_list - A single ENS_PART, part name, part id, or a list of these
-                      For per part constants this is necessary so if empty, will
-                      be all parts
-    
-          undef_none - if False (default) returns undef value (ensight.Undefined) if var
-                       value is undefined OR
-                       if True, returns None for undefined 
-    
-          Return if a Constant
-                 the float value of a constant
-                 OR
-                 ensight.Undefined if var is undefined and undef_none is False (default)
-                 OR
-                 None if error or if var is undefined and undef_none is True
-    
-                 NEW in 10.2
-                 if a Per part constant returns a list of values, corresponding to
-                 each part in the input part list 
-                  a list of float values if per part constant
-                 OR
-                  a list of float and None values if undef_none is True
-                 OR
-                  [ ] if error
-    
+        part_list: list
+            The list of part objects to get the constant values on. It can either be a list of names
+            a list of IDs (integers or strings) or directly a list of ENS_PART objects.
+            If not provided, all the parts will be considered.
+
+        undef_none: bool
+            if False (default) returns undef value (ensight.Undefined) if var
+            value is undefined. If False, for undefined values None will be returned
+
+        Returns
+        -------
+        float or list of float:
+            if the variable is a constant, it will either return the constant value, ensight.Undefined or None
+            depending on the input.
+            If the variable is a constant per part, a list of floats, ensight.Undefined or None will be returned
         """
         if not part_list:
             part_list = self.ensight.objs.core.PARTS
@@ -631,75 +727,93 @@ class Variables:
         #
         #  error checking
         #
-        if isinstance(cname,str):
+        if isinstance(cname, str):
             if len(cname) > 0:
                 const_name = cname
-                if const_name in self.get_const_var_names(v_type=ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART):
-                    const_type = ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART
-                elif const_name in self.get_const_var_names(v_type=ensight.objs.enums.ENS_VAR_CONSTANT):
-                    const_type = ensight.objs.enums.ENS_VAR_CONSTANT
+                if const_name in self.get_const_var_names(
+                    v_type=self.ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART
+                ):
+                    const_type = self.ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART
+                elif const_name in self.get_const_var_names(
+                    v_type=self.ensight.objs.enums.ENS_VAR_CONSTANT
+                ):
+                    const_type = self.ensight.objs.enums.ENS_VAR_CONSTANT
                 else:
-                    print("Error, {} Constant name {} is not a constant nor a per part constant".format( ens_routine,const_name))
-                    return None
+                    raise RuntimeError(
+                        "Error, {} Constant name {} is not a constant nor a per part constant".format(
+                            ens_routine, const_name
+                        )
+                    )
             else:
-                print("Error, {} must supply a valid constant variable name ".format(ens_routine))
-                return None
+                raise RuntimeError(
+                    "Error, {} must supply a valid constant variable name ".format(ens_routine)
+                )
         elif isinstance(cname, self.ensight.objs.ENS_VAR):
             const_name = cname.DESCRIPTION
             const_type = cname.VARTYPEENUM
-            if const_type != self.ensight.objs.enums.ENS_VAR_CONSTANT and const_type != self.ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART:
-                print("Error, Variable {} is not a constant nor a per part constant".format(cname))
-                return None
+            if (
+                const_type != self.ensight.objs.enums.ENS_VAR_CONSTANT
+                and const_type != self.ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART
+            ):
+                raise RuntimeError(
+                    "Error, Variable {} is not a constant nor a per part constant".format(cname)
+                )
         else:
-            print("Error, 'get_const_val' Constant name is neither string nor ENS_VAR")
-            return None
+            raise RuntimeError("Error, 'get_const_val' Constant name is neither string nor ENS_VAR")
         #
         #
         #  Now get it
         #
-        self.ensight.variables.activate(const_name) # bug fixed 10.1.6(c)
-        
-        if const_type == self.ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART: # new in 10.2
-    
+        self.ensight.variables.activate(const_name)  # bug fixed 10.1.6(c)
+
+        if const_type == self.ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART:  # new in 10.2
             if not part_list:
                 part_list = self.ensight.objs.core.PARTS
-    
-            plist = self.get_part_id_obj_name(part_list,'obj')
-            ret_val = []
+
+            plist = self.ensight.utils.parts.get_part_id_obj_name(part_list, "obj")
+            ret_val: List[Optional[float]] = []
             #
             for prt in plist:
-                if isinstance(prt,ensight.objs.ENS_PART):
+                if isinstance(prt, self.ensight.objs.ENS_PART):
                     val_dict = prt.get_values([const_name])
                     if val_dict:
-                        val = val_dict[const_name][0]
-                        if undef_none == True and  np.isclose( val , self.ensight.Undefined, rtol=1e-6,atol=1e-16):
+                        val = float(val_dict[const_name][0])
+                        if undef_none and np.isclose(
+                            val, self.ensight.Undefined, rtol=1e-6, atol=1e-16
+                        ):
                             ret_val.append(None)
                         else:
                             ret_val.append(val)
                 else:
-                    print("Error {} part list must contain a list of only ENS_PARTs".format(ens_routine))
+                    raise RuntimeError(
+                        "Error {} part list must contain a list of only ENS_PARTs".format(
+                            ens_routine
+                        )
+                    )
             return ret_val
-        else: # the legacy way using the interface manual ch 6
-    
-            (val,type_val,scope_val) = self.ensight.ensvariable(const_name)
-    
-            # type = 0 if the value is an integer, 1 if the value is a float and 2 if the value is a string
-            # scope =  -1 if it is a constant computed in EnSight, and
-            #             scope will be >= 0 if a command language global
-            #             (0 if command language global and >0 if local to a file or loop)
-            if scope_val == -1  and type_val == 1: # EnSight constant and float
-                if undef_none == True and  np.isclose( val , self.ensight.Undefined, rtol=1e-6,atol=1e-16):
-                    return None
-                else:
-                    return val
-            else:
-                print("Error, {} return value from ensight.ensvariable indicates it is not a float from an Ensight Constant".format(ens_routine))
+        # the legacy way using the interface manual ch 6
+        (val, type_val, scope_val) = self.ensight.ensvariable(const_name)
+
+        # type = 0 if the value is an integer, 1 if the value is a float and 2 if the value is a string
+        # scope =  -1 if it is a constant computed in EnSight, and
+        #             scope will be >= 0 if a command language global
+        #             (0 if command language global and >0 if local to a file or loop)
+        if scope_val == -1 and type_val == 1:  # EnSight constant and float
+            if undef_none and np.isclose(val, self.ensight.Undefined, rtol=1e-6, atol=1e-16):
                 return None
+            else:
+                return val
+        else:
+            raise RuntimeError(
+                "Error, {} return value from ensight.ensvariable indicates it is not a float from an Ensight Constant".format(
+                    ens_routine
+                )
+            )
 
     #
     #
     # IN:
-    #  part object list 
+    #  part object list
     #  var_object -     Must be an elemental variable
     #  frame_index -    if > 0 and frame exists, use that frame to calc cylindrical forces
     # OUT:
@@ -714,7 +828,7 @@ class Variables:
     #       ENS_Force_press_cyl is the conversion of ENS_Force_press to cylindrical coords
     #       ENS_Force_press_R - Radial component of the pressure force in frame index
     #       ENS_Force_press_T - Angular (theta)  component of the pressure force in frame index
-    #       ENS_Force_press_A - Axial (z component of chosen frame) of the pressure force 
+    #       ENS_Force_press_A - Axial (z component of chosen frame) of the pressure force
     #
     #   WARNING: Each time you call this function, it
     #     overwrites all these EnSight variables.
@@ -725,122 +839,154 @@ class Variables:
     #    Return: True if success
     #            False if error
     #
-    def _press_force_xyz_rtz(self, pobj_list, press_var_obj, frame_index = 0):
+    def _press_force_xyz_rtz(
+        self,
+        pobj_list: Optional[List[Union[str, int, "ENS_PART"]]] = None,
+        press_var_obj: Optional["ENS_VAR"] = None,
+        frame_index: Optional[int] = 0,
+    ) -> bool:
+        """
+        Compute the pressure force in the cartesian and cylindrical space.
+        It creates (or recreates) several intermediate vars:
+
+        - ENS_Force_press
+        - ENS_Force_press_X
+        - ENS_Force_press_Y
+        - ENS_Force_press_Z
+        if frame index > 0 and the frame exists:
+        - ENS_Force_press_cyl is the conversion of ENS_Force_press to cylindrical coords
+        - ENS_Force_press_R - Radial component of the pressure force in frame index
+        - ENS_Force_press_T - Angular (theta)  component of the pressure force in frame index
+        - ENS_Force_press_A - Axial (z component of chosen frame) of the pressure force
+
+        WARNING: Each time you call this function, it
+        overwrites all these EnSight variables.
+
+
+        Parameters
+        ----------
+        pobj_list: list
+            The list of part objects to compute the forces on. It can either be a list of names
+            a list of IDs (integers or strings) or directly a list of ENS_PART objects
+        press_var_obj: ENS_VAR
+            The variable object to use as pressure variable. If nodal, it will be converted
+            into an elemental variable
+        frame_index: int
+            The eventual frame index on which to compute the cylindrical components of the forces
+
+        Returns
+        -------
+        bool
+            True if the computation was successful
+
+        """
         #
         # This pobj_list should contain only 2D parts
         #
-        if len(pobj_list) < 1:
-            self.ensight.int_message("Error, no part provided",1)
-            return False
+        if not frame_index:
+            frame_index = 0
+        varid = convert_variable(self.ensight, press_var_obj)
+        _press_var_obj: "ENS_VAR"
+        values = self.ensight.objs.core.VARIABLES.find(varid, "ID")
+        ensvar_values: List["ENS_VAR"]
+        ensvar_values = [v for v in values]
+        _press_var_obj = ensvar_values[0]
+        if not pobj_list:
+            raise RuntimeError("Error, no part provided")
         #
         # select all parts in list
         #
-        self.ensight.utils.parts.select_parts(pobj_list)
+        _pobj_list: List["ENS_PART"]
+        _pobj_list = self.ensight.utils.parts.select_parts(pobj_list)
+        if not _pobj_list:
+            return False
         #
         # makes a new elem var if input var is nodal
         #
-        if press_var_obj.LOCATION == self.ensight.objs.enums.ENS_VAR_ELEM:
-            press_var_name = press_var_obj.DESCRIPTION
+        new_pres_var_obj: "ENS_VAR"
+        press_var_name: str
+        if _press_var_obj.LOCATION != self.ensight.objs.enums.ENS_VAR_ELEM:
+            # tricks for mypy
+            values = self._move_var_to_elem(_pobj_list, _press_var_obj)
+            ensvar_values = [v for v in values]
+            new_pres_var_obj = ensvar_values[0]
+            press_var_name = new_pres_var_obj.DESCRIPTION
         else:
-            err_string = "Error press_force_xyz_rtz: variable '{}' is not an elemental variable".format(press_var_obj.DESCRIPTION)
-            self.ensight.int_message(err_string,1)
-            return False
+            press_var_name = new_pres_var_obj.DESCRIPTION
+
         #
         # Calculate the Force vector
         #
-        calc_string = "(plist," + press_var_name + ')'
-        force_calc_string = 'ENS_Force_press = Force'
+        calc_string = "(plist," + press_var_name + ")"
+        force_calc_string = "ENS_Force_press = Force"
         temp_string = force_calc_string + calc_string
-        if 0 != self._calc_var(pobj_list,temp_string):
-            self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
-            return False
-        #
-        # Calculate the force components
-        #
-        self.ensight.utils.parts.select_parts(pobj_list)
-        temp_string = 'ENS_Force_press_X = ENS_Force_press[X]'
-        if 0 != self._calc_var(pobj_list,temp_string):
-            self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
-            return False
-    
-        temp_string = 'ENS_Force_press_Y = ENS_Force_press[Y]'
-        if 0 != self._calc_var(pobj_list,temp_string):
-            self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
-            return False
-    
-        temp_string = 'ENS_Force_press_Z = ENS_Force_press[Z]'
-        if 0 != self._calc_var(pobj_list,temp_string):
-            self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
-            return False
+        if not self._calc_var(_pobj_list, temp_string):
+            raise RuntimeError("Error calculating: '" + temp_string + "'")
+
+        temp_string = "ENS_Force_press_X = ENS_Force_press[X]"
+        if not self._calc_var(_pobj_list, temp_string):
+            raise RuntimeError("Error calculating: '" + temp_string + "'")
+
+        temp_string = "ENS_Force_press_Y = ENS_Force_press[Y]"
+        if not self._calc_var(_pobj_list, temp_string):
+            raise RuntimeError("Error calculating: '" + temp_string + "'")
+
+        temp_string = "ENS_Force_press_Z = ENS_Force_press[Z]"
+        if not self._calc_var(_pobj_list, temp_string):
+            raise RuntimeError("Error calculating: '" + temp_string + "'")
         #
         #  RTZ Cylindrical force
         #
         if frame_index > 0 and frame_index < len(self.ensight.objs.core.FRAMES):
-            temp_string = "ENS_Force_press_cyl = RectToCyl(plist,ENS_Force_press,"+ str(frame_index)+")"
-            if 0 != self._calc_var(pobj_list,temp_string):
-                self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
-                return False
-    
+            temp_string = (
+                "ENS_Force_press_cyl = RectToCyl(plist,ENS_Force_press," + str(frame_index) + ")"
+            )
+            if not self._calc_var(_pobj_list, temp_string):
+                raise RuntimeError("Error calculating: '" + temp_string + "'")
+
             temp_string = "ENS_Force_press_R = ENS_Force_press_cyl[X]"
-            if 0 != self._calc_var(pobj_list,temp_string):  # radial force
-                self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
-                return False
-    
+            if not self._calc_var(_pobj_list, temp_string):  # radial force
+                raise RuntimeError("Error calculating: '" + temp_string + "'")
+
             temp_string = "ENS_Force_press_T  = ENS_Force_press_cyl[Y]"
-            if 0 != self._calc_var(pobj_list,temp_string): # angular force
-                self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
-                return False
-    
+            if not self._calc_var(pobj_list, temp_string):  # angular force
+                raise RuntimeError("Error calculating: '" + temp_string + "'")
+
             temp_string = "ENS_Force_press_A  = ENS_Force_press_cyl[Z]"
-            if 0 != self._calc_var(pobj_list,temp_string): # axial force        
-                self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
-                return False
+            if not self._calc_var(_pobj_list, temp_string):  # axial force
+                raise RuntimeError("Error calculating: '" + temp_string + "'")
         return True
 
+    def _sum_pressure_forces_xyz_rtz(
+        self,
+        pobj_list: Optional[List[Union[str, int, "ENS_PART"]]] = None,
+        frame_index: Optional[int] = 0,
+    ) -> Optional[List[List[float]]]:
+        """
+        Compute the sum of the pressure forces on the input part objects list
+        and on the eventual frame selected via the StatMoment calculator function in EnSight
 
-    #
-    #  Uses the stat moment to sum the forces for this list of parts
-    #   resulting in a per part constant and a case constant as of 10.2.0(d)
-    #   IN:
-    #     pobj_list - A list of ENS_PART(s)
-    #
-    #     frame_index = If 0 then do not calc RTZ cylindrical net forces
-    #                 otherwise calculate the net forces in Radial, Theta, and Axial
-    #   OUT:
-    #   calculates net pressure force per part constant using all parts
-    #    in the list and creates three or six per part constants:
-    #      ENS_Force_Net_press_X
-    #      ENS_Force_Net_press_Y
-    #      ENS_Force_Net_press_Z
-    #
-    #      if frame_index > 0, then calc net force using the
-    #       cylindrical forces in the frame_index reference system three additional
-    #       per part constants
-    #
-    #        ENS_Force_Net_press_R - net pressure force in the radial direction
-    #        ENS_Force_Net_press_T - net pressure force in the theta angular direction
-    #        ENS_Force_Net_press_A - net pressure force in the axial direction 
-    #
-    #   Returns:
-    #      if frame_index > 0 and frame exists then returns forces for each part in the list:
-    #         ( [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, ENS_Force_Net_press_R, ENS_Force_Net_press_T, ENS_Force_Net_press_A ] ,
-    #           [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, ENS_Force_Net_press_R, ENS_Force_Net_press_T, ENS_Force_Net_press_A ] ,
-    #           [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, ENS_Force_Net_press_R, ENS_Force_Net_press_T, ENS_Force_Net_press_A ] , ... )
-    #      else:
-    #         ( [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, 0.0, 0.0, 0.0] ,
-    #           [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, 0.0, 0.0, 0.0] ,
-    #           [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, 0.0, 0.0, 0.0] , ... )
-    #      ERROR:
-    #         [ ] if error calculating variables or getting back constant values
-    #
-    #
-    def sum_pressure_forces_xyz_rtz(self, pobj_list, frame_index=0):
-        #  
+        Parameters
+        ----------
+        pobj_list: list
+            The list of part objects to compute the forces on. It can either be a list of names
+            a list of IDs (integers or strings) or directly a list of ENS_PART objects
+        frame_index: int
+            The eventual frame index on which to compute the cylindrical components of the forces
+
+        Returns
+        -------
+        list
+            The list of computed force values. These will be per part constant variables.
+            Three if only cartesian, six if also the cylindrical components were computed.
+        """
+        #
         # This pobj_list should contain only 2D parts
         #
-        if len(pobj_list)<1 :
-            self.ensight.int_message("Error, no part provided",1)
-            return []
+        if not frame_index:
+            frame_index = 0
+        if not pobj_list:
+            raise RuntimeError("Error, no part provided")
         #
         # Select the part(s) in the list
         # ensight.variables.evaluate("ENS_Force_Net_press_Y = StatMoment(plist,pressure,0,Compute_Per_part)")
@@ -849,343 +995,922 @@ class Variables:
         # Calculate the net force X, Y, and Z , 10.2.0(d) now per part constant variable
         #
         force_calc_string = "ENS_Force_Net_press_X = StatMoment"
-        calc_string = "(plist," +  'ENS_Force_press_X , 0, Compute_Per_part )'
+        calc_string = "(plist," + "ENS_Force_press_X , 0, Compute_Per_part )"
         temp_string = force_calc_string + calc_string
-        if 0 != self._calc_var(pobj_list,temp_string):
-            return []
+        if not self._calc_var(pobj_list, temp_string):
+            return None
         #
         force_calc_string = "ENS_Force_Net_press_Y = StatMoment"
-        calc_string = "(plist," +  'ENS_Force_press_Y , 0, Compute_Per_part )'
+        calc_string = "(plist," + "ENS_Force_press_Y , 0, Compute_Per_part )"
         temp_string = force_calc_string + calc_string
-        if 0 != self._calc_var(pobj_list,temp_string):
-            return []
+        if not self._calc_var(pobj_list, temp_string):
+            return None
         #
         force_calc_string = "ENS_Force_Net_press_Z = StatMoment"
-        calc_string = "(plist," +  'ENS_Force_press_Z , 0, Compute_Per_part )'
+        calc_string = "(plist," + "ENS_Force_press_Z , 0, Compute_Per_part )"
         temp_string = force_calc_string + calc_string
-        if 0 != self._calc_var(pobj_list,temp_string):
-            return []
+        if not self._calc_var(pobj_list, temp_string):
+            return None
         #
         # Calculate the Total force X, Y, and Z , 10.2.0(d) now case constant variable
         #  Totals are a case constants. We don't do anything with these vars
         #   they are calc'd to give the user the totals.
         #
         force_calc_string = "ENS_Force_Total_Net_press_X = StatMoment"
-        calc_string = "(plist," +  'ENS_Force_press_X , 0, Compute_Per_case )'
+        calc_string = "(plist," + "ENS_Force_press_X , 0, Compute_Per_case )"
         temp_string = force_calc_string + calc_string
-        if 0 != self._calc_var(pobj_list,temp_string):
-            return []
+        if not self._calc_var(pobj_list, temp_string):
+            return None
         #
         force_calc_string = "ENS_Force_Total_Net_press_Y = StatMoment"
-        calc_string = "(plist," +  'ENS_Force_press_Y , 0, Compute_Per_case )'
+        calc_string = "(plist," + "ENS_Force_press_Y , 0, Compute_Per_case )"
         temp_string = force_calc_string + calc_string
-        if 0 != self._calc_var(pobj_list,temp_string):
-            return []
+        if not self._calc_var(pobj_list, temp_string):
+            return None
         #
         force_calc_string = "ENS_Force_Total_Net_press_Z = StatMoment"
-        calc_string = "(plist," +  'ENS_Force_press_Z , 0, Compute_Per_case )'
+        calc_string = "(plist," + "ENS_Force_press_Z , 0, Compute_Per_case )"
         temp_string = force_calc_string + calc_string
-        if 0 != self._calc_var(pobj_list,temp_string):
-            return []
+        if not self._calc_var(pobj_list, temp_string):
+            return None
         #
         # get a list with a per part force, one for each part, new 10.1.6(b)
         #
-        Fx = self.get_const_val("ENS_Force_Net_press_X",pobj_list)
-        Fy = self.get_const_val("ENS_Force_Net_press_Y",pobj_list)
-        Fz = self.get_const_val ("ENS_Force_Net_press_Z",pobj_list)
+
+        Fx: List[float] = []
+        Fy: List[float] = []
+        Fz: List[float] = []
+        val = self.get_const_val("ENS_Force_Net_press_X", pobj_list)
+        if not val:
+            return None
+        if val:
+            if isinstance(val, list):
+                for v in val:
+                    if not v:
+                        return None
+                    Fx.append(v)
+            else:
+                return None
+        val = self.get_const_val("ENS_Force_Net_press_Y", pobj_list)
+        if not val:
+            return None
+        if val:
+            if isinstance(val, list):
+                for v in val:
+                    if not v:
+                        return None
+                    Fy.append(v)
+            else:
+                return None
+        val = self.get_const_val("ENS_Force_Net_press_Z", pobj_list)
+        if not val:
+            return None
+        if val:
+            if isinstance(val, list):
+                for v in val:
+                    if not v:
+                        return None
+                    Fz.append(v)
+            else:
+                return None
         #
         #
         # Fr, Ft, Fa
         #
-        if frame_index > 0 and frame_index < len(self.ensight.objs.core.FRAMES): # user picked non-zero frame index
+        if frame_index > 0 and frame_index < len(
+            self.ensight.objs.core.FRAMES
+        ):  # user picked non-zero frame index
             #
             self.ensight.utils.parts.select_parts(pobj_list)
             #
             #  per part constant as of 10.2.0(d)
             #
             force_calc_string = "ENS_Force_Net_press_R = StatMoment"
-            calc_string = "(plist," + 'ENS_Force_press_R, 0, Compute_Per_part )'
+            calc_string = "(plist," + "ENS_Force_press_R, 0, Compute_Per_part )"
             temp_string = force_calc_string + calc_string
-            if 0 != self._calc_var(pobj_list,temp_string):
-                return []
+            if not self._calc_var(pobj_list, temp_string):
+                return None
             #
             force_calc_string = "ENS_Force_Net_press_T = StatMoment"
-            calc_string = "(plist," + 'ENS_Force_press_T, 0, Compute_Per_part )'
+            calc_string = "(plist," + "ENS_Force_press_T, 0, Compute_Per_part )"
             temp_string = force_calc_string + calc_string
-            if 0 != self._calc_var(pobj_list,temp_string):
-                return []
+            if not self._calc_var(pobj_list, temp_string):
+                return None
             #
             force_calc_string = "ENS_Force_Net_press_A = StatMoment"
-            calc_string = "(plist," + 'ENS_Force_press_A, 0, Compute_Per_part )'
+            calc_string = "(plist," + "ENS_Force_press_A, 0, Compute_Per_part )"
             temp_string = force_calc_string + calc_string
-            if 0 != self._calc_var(pobj_list,temp_string):
-                return []
+            if not self._calc_var(pobj_list, temp_string):
+                return None
             #
             #  Totals are a case constants. We don't do anything with these vars
             #   they are calc'd to give the user the totals.
             #
             force_calc_string = "ENS_Force_Total_Net_press_R = StatMoment"
-            calc_string = "(plist," + 'ENS_Force_press_R, 0, Compute_Per_case )'
+            calc_string = "(plist," + "ENS_Force_press_R, 0, Compute_Per_case )"
             temp_string = force_calc_string + calc_string
-            if 0 != self._calc_var(pobj_list,temp_string):
-                return []
+            if not self._calc_var(pobj_list, temp_string):
+                return None
             #
             force_calc_string = "ENS_Force_Total_Net_press_T = StatMoment"
-            calc_string = "(plist," + 'ENS_Force_press_T, 0, Compute_Per_case )'
+            calc_string = "(plist," + "ENS_Force_press_T, 0, Compute_Per_case )"
             temp_string = force_calc_string + calc_string
-            if 0 != self._calc_var(pobj_list,temp_string):
-                return []
+            if not self._calc_var(pobj_list, temp_string):
+                return None
             #
             force_calc_string = "ENS_Force_Total_Net_press_A = StatMoment"
-            calc_string = "(plist," + 'ENS_Force_press_A, 0, Compute_Per_case )'
+            calc_string = "(plist," + "ENS_Force_press_A, 0, Compute_Per_case )"
             temp_string = force_calc_string + calc_string
-            if 0 != self._calc_var(pobj_list,temp_string):
-                return []
+            if not self._calc_var(pobj_list, temp_string):
+                return None
             #
             #   get a list with a per part force, one for each part, new 10.1.6(b)
             #
-            Fr = self.get_const_val("ENS_Force_Net_press_R",pobj_list)
-            Ft = self.get_const_val("ENS_Force_Net_press_T",pobj_list)
-            Fa = self.get_const_val("ENS_Force_Net_press_A",pobj_list)
+            Fr: List[float] = []
+            Ft: List[float] = []
+            Fa: List[float] = []
+            val = self.get_const_val("ENS_Force_Net_press_R", pobj_list)
+            if not val:
+                return None
+            if val:
+                if isinstance(val, list):
+                    for v in val:
+                        if not v:
+                            return None
+                        Fr.append(v)
+                else:
+                    return None
+            val = self.get_const_val("ENS_Force_Net_press_T", pobj_list)
+            if not val:
+                return None
+            if val:
+                if isinstance(val, list):
+                    for v in val:
+                        if not v:
+                            return None
+                        Ft.append(v)
+                else:
+                    return None
+            val = self.get_const_val("ENS_Force_Net_press_A", pobj_list)
+            if not val:
+                return None
+            if val:
+                if isinstance(val, list):
+                    for v in val:
+                        if not v:
+                            return None
+                        Fa.append(v)
+                else:
+                    return None
             #
-            if Fr != None and Ft != None and Fa != None and Fx != None and Fy != None and Fz != None: 
+            if all([Fr, Ft, Fz, Fx, Fy, Fz]):
                 ret_val = []
                 for ii in range(len(pobj_list)):
-                    ret_val.append([Fx[ii],Fy[ii],Fz[ii],Fr[ii],Ft[ii],Fa[ii]])
+                    ret_val.append([Fx[ii], Fy[ii], Fz[ii], Fr[ii], Ft[ii], Fa[ii]])
                 return ret_val
             else:
                 err_string = "Error getting XYZ and/or Cylindrical RTZ Pressure Net Force per part constant values"
-                self.ensight.int_message(err_string,1)
-                return []
-        else: # either only one Frame or Frame 0 has been chosen so no cylindrical calc
-            if Fx != None and Fy != None and Fz != None: 
+                raise RuntimeError(err_string)
+        else:  # either only one Frame or Frame 0 has been chosen so no cylindrical calc
+            if all([Fx, Fy, Fz]):
                 ret_val = []
                 for ii in range(len(pobj_list)):
-                    ret_val.append([Fx[ii],Fy[ii],Fz[ii],0.0,0.0,0.0])
+                    ret_val.append([Fx[ii], Fy[ii], Fz[ii], 0.0, 0.0, 0.0])
                 return ret_val
             else:
-                err_string = "Error getting Fx, Fy, and/or Fz Pressure Net force per part constant values"
-                self.ensight.int_message(err_string,1)
-                return []
+                err_string = (
+                    "Error getting Fx, Fy, and/or Fz Pressure Net force per part constant values"
+                )
+                raise RuntimeError(err_string)
 
-    #
-    #  Writes out the lists part by part
-    #
-    def write_out_force_data(self, filename, original_part_selection_list, params, press_force_list, shear_force_list, press_coeff_list, shear_coeff_list, \
-        press_LDS_force_list, shear_LDS_force_list, press_LDS_coeff_list, shear_LDS_coeff_list):
-    
-        if len(press_force_list) > 0:  # FIX ME what if we have no pressure force list but do have shear force list???
+    def _write_out_force_data(
+        self,
+        filename: str,
+        original_part_selection_list: List["ENS_PART"],
+        params: Dict[str, str],
+        press_force_list: Optional[List[List[float]]] = None,
+        shear_force_list: Optional[List[List[float]]] = None,
+        press_coeff_list: Optional[List[List[float]]] = None,
+        shear_coeff_list: Optional[List[List[float]]] = None,
+        press_LDS_force_list: Optional[List[List[float]]] = None,
+        shear_LDS_force_list: Optional[List[List[float]]] = None,
+        press_LDS_coeff_list: Optional[List[List[float]]] = None,
+        shear_LDS_coeff_list: Optional[List[List[float]]] = None,
+    ) -> bool:
+        """
+        Write the computed forces in a file split part by part
+
+        Parameters
+        ----------
+        filename: str
+            the file on which to write the force data
+        params: dict
+            A dictionary containing the settings for the file. It can contain:
+            press_varname: the name of the pressure variable
+            shear_varname: the name of the shear variable
+            shear_vartype: the type of shear variable
+            Area_ref: the reference area for the force coefficients computation
+            Dens_ref: the reference density for the force coefficients computation
+            Vx_ref: the X velocity reference for the force coefficients computation
+            Vy_ref: the Y velocity reference for the force coefficients computation
+            Vz_ref: the Z velocity reference for the force coefficients computation
+            up_vector: the "Up vector" used for the force components computation
+            frame_index: the index of the frame used for the cylindrical components computation
+        press_force_list: list
+            the list of pressure forces to write
+        shear_force_list: list
+            the list of shear forces to write
+        press_coeff_list:
+            the list of pressure force coefficients to write
+        shear_coeff_list:
+            the list of shear force coefficients to write
+        press_LDS_force_list:
+            the list of pressure Lift, Drag, Side force components to write
+        shear_LDS_force_list:
+            the list of shear Lift, Drag, Side force components to write
+        press_LDS_coeff_list:
+            the list of pressure Lift, Drag, Side force coefficients components to write
+        shear_LDS_coeff_list:
+            the list of pressure Lift, Drag, Side force coefficients components to write
+
+        Returns
+        -------
+        bool
+            True if the export was successful
+        """
+        frames = (
+            self.ensight.objs.core.FRAMES is not None
+            and "frame_index" in params
+            and int(params["frame_index"]) > 0
+        )
+        shear = (
+            "shear_varname" in params
+            and params["shear_varname"] != "None"
+            and params["shear_vartype"] != "None"
+        )
+        if (
+            press_force_list
+        ):  # FIX ME what if we have no pressure force list but do have shear force list???
             try:
-                fp = open(filename,"w")
-            except:
-                self.ensight.int_message("Error Failed to open output csv filename for writing '" + filename +"'",1)
-                return False
-    
-            if 1: 
-                temp_list = [0.,0.,0.]
-                #
-                #  get the input data filename from the server and write the filename for the current case
-                #                    
-                c = self.ensight.objs.core.CURRENTCASE[0]    # for c in ensight.objs.core.CASES.find(True, attr=ensight.objs.enums.ACTIVE):
-                fp.write("'"+os.path.join(c.SERVERDIR, c.SERVERINFO.get('file',''))+"'\n")
-                #
-                #  Write the gui input values to the .csv output file as  a second
-                #   line in the header
-                #
-                fp.write("Pressure variable name ," + params['press_varname'] + "\n")
-                if len(self.ensight.objs.core.FRAMES) > 0:
-                    if 'frame_index' in params:
-                        fp.write("Cylindrical reference frame coordinate system frame, " + str(params['frame_index'])+ "\n")
-                if ( 'shear_varname' in params) and ( params['shear_varname'] != "None") and ( params['shear_vartype'] != "None"):
-                    fp.write("Shear variable name, " + params['shear_varname'] + ", " + "\n")
-                    fp.write("Shear variable type, " + params['shear_vartype'] + "\n" )
-                if params['Area_ref'] > 0.0:
-                    fp.write("Reference Area, %.5f \n" % params['Area_ref'] )
-                    fp.write("Reference Density, %.5f \n" % params['Dens_ref'] )
-                    fp.write("Reference Velocity xyz, %.5f," % params['Vx_ref']  )
-                    fp.write("%.5f, " % params['Vy_ref'])
-                    fp.write("%.5f  \n" % params['Vz_ref'] )
-                    if (params['up_vector'] != "None"):
-                        fp.write('Up vector,' + params['up_vector'] + '\n')
-                fp.write("\n")
-                        
-                fp.write("Part ID,   Part Name , Pressure Force X , Pressure Force Y , Pressure Force Z , Total Pressure Force ")
-                if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
-                    fp.write(", Pressure Force Radial , Pressure Force Theta , Pressure Force Axial, Total Cyl Pressure Force ")
-                if len(shear_force_list):
-                    fp.write(", Shear Force X , Shear Force Y , Shear Force Z , Total Shear Force ")
-                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
-                        fp.write(", Shear Force Radial , Shear Force Theta , Shear Force Axial , Total Cyl Shear Force ")
-                    fp.write(", Press + Shear Force X , Press + Shear Force Y , Press + Shear Force Z , Total Press + Shear Force ")
-                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
-                        fp.write(", Press + Shear Force Radial , Press + Shear Force Theta , Press + Shear Force Axial , Total Press + Shear Force ")
-                if len(press_coeff_list):
-                    fp.write(", Coeff Press X , Coeff Press Y , Coeff Press Z , Total Coeff Press ")
-                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
-                        fp.write(", Coeff Press Radial , Coeff Press Theta , Coeff Press Axial , Total Coeff Press ")
-                if len(shear_coeff_list):
-                    fp.write(", Coeff Shear X , Coeff Shear Y , Coeff Shear Z , Total Coeff Shear ,")
-                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
-                        fp.write("Coeff Shear Radial , Coeff Shear Theta , Coeff Shear Axial , Total Coeff Shear ,")
-                    fp.write("Coeff Press + Shear X , Coeff Press + Shear Y , Coeff Press + Shear Z , Total Coeff Press + Shear")
-                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
-                        fp.write(", Coeff Press + Shear Radial , Coeff Press + Shear Theta , Coeff Press + Shear Axial , Total Coeff Press + Shear")
-                if len(press_LDS_force_list):
-                    fp.write(", Lift Force , Drag Force , Side Force , Total Pressure Force ")
-                if len(shear_LDS_force_list):
-                    fp.write(", Shear Force L , Shear Force D , Shear Force Side , Total Shear Force LDS ")
-                    fp.write(", Press + Shear Force L , Press + Shear Force D , Press + Shear Force Side , Total Press + Shear Force LDS ")
-                if len(press_LDS_coeff_list):
-                    fp.write(", Lift Coeff Press  , Drag Coeff Press , Side Coeff Press , Total Coeff Press ")
-                if len(shear_LDS_coeff_list):
-                    fp.write(", Lift Coeff Shear  , Drag Coeff Shear , Side Coeff Shear , Coeff Shear LDS Total,")
-                    fp.write("Coeff Press + Shear L , Coeff Press + Shear D , Coeff Press + Shear Side , Coeff Press + Shear LDS Total")
-                fp.write("\n")
-                #
-                #  Loop through and write out the vals
-                #
-                for ii in range(len(press_force_list)):
-                    fp.write(str(original_part_selection_list[ii].PARTNUMBER) + " , " + original_part_selection_list[ii].DESCRIPTION + " , ")
+                with open(filename, "w") as fp:
+                    temp_list = [0.0, 0.0, 0.0]
                     #
-                    # pressure force components then magnitude
+                    #  get the input data filename from the server and write the filename for the current case
                     #
-                    for jj in range(3):
-                        fp.write(str(press_force_list[ii][jj]))
-                        fp.write(" , ")
-                    fp.write(str( vec_mag(press_force_list[ii][:3]) )) # magnitude of Fx, Fy, Fz
-                    if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
-                        fp.write(" , ")
-                        for jj in range(3):
-                            fp.write(str(press_force_list[ii][jj+3]))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(press_force_list[ii][3:]) )) # magnitude of Cyl Fr, Ft, Fa
-                     #
-                    # shear force components then magnitude
+                    c = self.ensight.objs.core.CURRENTCASE[
+                        0
+                    ]  # for c in ensight.objs.core.CASES.find(True, attr=ensight.objs.enums.ACTIVE):
+                    fp.write("'" + os.path.join(c.SERVERDIR, c.SERVERINFO.get("file", "")) + "'\n")
                     #
-                    if len(shear_force_list) > 0:
-                        fp.write(" , ")
-                        for jj in range(3):
-                            fp.write(str(shear_force_list[ii][jj]))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(shear_force_list[ii][:3]) ))
-                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
-                            fp.write(" , ")
-                            for jj in range(3):
-                                fp.write(str(shear_force_list[ii][jj+3]))
-                                fp.write(" , ")
-                            fp.write(str( vec_mag(shear_force_list[ii][3:]) ))
-                        fp.write(" , ")
-                        # sum of pressure and shear forces components then magnitude
-                        for jj in range(3):
-                            temp_list[jj] = press_force_list[ii][jj] + shear_force_list[ii][jj]
-                            fp.write(str( temp_list[jj] ))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(temp_list[:3]) ))
-                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
-                            fp.write(" , ")
-                            for jj in range(3):
-                                temp_list[jj] = press_force_list[ii][jj+3] + shear_force_list[ii][jj+3]
-                                fp.write(str( temp_list[jj] ))
-                                fp.write(" , ")
-                            fp.write(str( vec_mag(temp_list[:3]) ))
-                            
+                    #  Write the gui input values to the .csv output file as  a second
+                    #   line in the header
                     #
-                    # Coefficient of pressure force components then magnitude
-                    #
-                    if len(press_coeff_list) > 0:
-                        fp.write(" , ")
-                        for jj in range(3):
-                            fp.write(str(press_coeff_list[ii][jj]))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(press_coeff_list[ii][:3]) ))
-                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
-                            fp.write(" , ")
-                            for jj in range(3):
-                                fp.write(str(press_coeff_list[ii][jj+3]))
-                                fp.write(" , ")
-                            fp.write(str( vec_mag(press_coeff_list[ii][3:]) )) 
-                    #
-                    # Coefficient shear force components then magnitude
-                    #
-                    if len(shear_coeff_list) > 0:
-                        fp.write(" , ")
-                        for jj in range(3):
-                            fp.write(str(shear_coeff_list[ii][jj]))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(shear_coeff_list[ii][:3]) ))
-                        fp.write(" , ")
-                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
-                            for jj in range(3):
-                                fp.write(str(shear_coeff_list[ii][jj+3]))
-                                fp.write(" , ")
-                            fp.write(str( vec_mag(shear_coeff_list[ii][3:]) ))
-                            fp.write(" , ")
-                        # sum of pressure and shear Coefficient components then magnitude
-                        for jj in range(3):
-                            temp_list[jj] = press_coeff_list[ii][jj] + shear_coeff_list[ii][jj]
-                            fp.write(str( temp_list[jj] ))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(temp_list) ))
-                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
-                            fp.write(" , ")
-                            for jj in range(3):
-                                temp_list[jj] = press_coeff_list[ii][jj+3] + shear_coeff_list[ii][jj+3]
-                                fp.write(str( temp_list[jj] ))
-                                fp.write(" , ")
-                            fp.write(str( vec_mag(temp_list) ))
-                        fp.write(" , ")
-                    #
-                    # Lift, Drag and Side Force
-                    # No cylindrical stuff here
-                    # LDS pressure force components then magnitude
-                    #
-                    if len(press_LDS_force_list) > 0:
-                        for jj in range(3):
-                            fp.write(str(press_LDS_force_list[ii][jj]))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(press_LDS_force_list[ii][:3]) ))
-                        fp.write(" , ")
-                    # LDS shear force components then magnitude
-                    if len(shear_LDS_force_list) > 0:
-                        for jj in range(3):
-                            fp.write(str(shear_LDS_force_list[ii][jj]))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(shear_LDS_force_list[ii][:3]) ))
-                        fp.write(" , ")
-                        # LDS sum of pressure and shear forces components then magnitude
-                        for jj in range(3):
-                            temp_list[jj] = press_LDS_force_list[ii][jj] + shear_LDS_force_list[ii][jj]
-                            fp.write(str( temp_list[jj] ))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(temp_list) ))
-                        fp.write(" , ")
-                    # LDS Coefficient of pressure force components then magnitude
-                    if len(press_LDS_coeff_list) > 0:
-                        for jj in range(3):
-                            fp.write(str(press_LDS_coeff_list[ii][jj]))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(press_LDS_coeff_list[ii][:3]) ))
-                        fp.write(" , ")
-                    # LDS Coefficient shear force components then magnitude
-                    if len(shear_LDS_coeff_list) > 0:
-                        for jj in range(3):
-                            fp.write(str(shear_LDS_coeff_list[ii][jj]))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(shear_LDS_coeff_list[ii][:3] ) ))
-                        fp.write(" , ")
-                        # LDS sum of pressure and shear Coefficient components then magnitude
-                        for jj in range(3):
-                            temp_list[jj] = press_LDS_coeff_list[ii][jj] + shear_LDS_coeff_list[ii][jj]
-                            fp.write(str( temp_list[jj] ))
-                            fp.write(" , ")
-                        fp.write(str( vec_mag(temp_list) ))
+                    fp.write("Pressure variable name ," + params["press_varname"] + "\n")
+                    if frames:
+                        fp.write(
+                            "Cylindrical reference frame coordinate system frame, "
+                            + str(params["frame_index"])
+                            + "\n"
+                        )
+                    if shear:
+                        fp.write("Shear variable name ," + params["shear_varname"] + ", " + "\n")
+                        fp.write("Shear variable type ," + params["shear_vartype"] + "\n")
+                    if (
+                        params.get("Area_ref")
+                        and params.get("Dens_ref")
+                        and params.get("Vx_ref")
+                        and params.get("Vy_ref")
+                        and params.get("Vz_ref")
+                    ):
+                        if float(params["Area_ref"]) > 0.0:
+                            fp.write("Reference Area, %.5f \n" % float(params["Area_ref"]))
+                            fp.write("Reference Density, %.5f \n" % float(params["Dens_ref"]))
+                            fp.write("Reference Velocity xyz, %.5f," % float(params["Vx_ref"]))
+                            fp.write("%.5f, " % float(params["Vy_ref"]))
+                            fp.write("%.5f  \n" % float(params["Vz_ref"]))
+                            if params.get("up_vector"):
+                                if params["up_vector"] != "None":
+                                    fp.write("Up vector," + params["up_vector"] + "\n")
+                        fp.write("\n")
+                    fp.write(
+                        "Part ID,   Part Name , Pressure Force X , Pressure Force Y , Pressure Force Z , Total Pressure Force "
+                    )
+                    if frames:
+                        fp.write(
+                            ", Pressure Force Radial , Pressure Force Theta , Pressure Force Axial, Total Cyl Pressure Force "
+                        )
+                    if shear_force_list:
+                        fp.write(
+                            ", Shear Force X , Shear Force Y , Shear Force Z , Total Shear Force "
+                        )
+                        if frames:
+                            fp.write(
+                                ", Shear Force Radial , Shear Force Theta , Shear Force Axial , Total Cyl Shear Force "
+                            )
+                        fp.write(
+                            ", Press + Shear Force X , Press + Shear Force Y , Press + Shear Force Z , Total Press + Shear Force "
+                        )
+                        if frames:
+                            fp.write(
+                                ", Press + Shear Force Radial , Press + Shear Force Theta , Press + Shear Force Axial , Total Press + Shear Force "
+                            )
+                    if press_coeff_list:
+                        fp.write(
+                            ", Coeff Press X , Coeff Press Y , Coeff Press Z , Total Coeff Press "
+                        )
+                        if frames:
+                            fp.write(
+                                ", Coeff Press Radial , Coeff Press Theta , Coeff Press Axial , Total Coeff Press "
+                            )
+                    if shear_coeff_list:
+                        fp.write(
+                            ", Coeff Shear X , Coeff Shear Y , Coeff Shear Z , Total Coeff Shear ,"
+                        )
+                        if frames:
+                            fp.write(
+                                "Coeff Shear Radial , Coeff Shear Theta , Coeff Shear Axial , Total Coeff Shear ,"
+                            )
+                        fp.write(
+                            "Coeff Press + Shear X , Coeff Press + Shear Y , Coeff Press + Shear Z , Total Coeff Press + Shear"
+                        )
+                        if frames:
+                            fp.write(
+                                ", Coeff Press + Shear Radial , Coeff Press + Shear Theta , Coeff Press + Shear Axial , Total Coeff Press + Shear"
+                            )
+                    if press_LDS_force_list:
+                        fp.write(", Lift Force , Drag Force , Side Force , Total Pressure Force ")
+                    if shear_LDS_force_list:
+                        fp.write(
+                            ", Shear Force L , Shear Force D , Shear Force Side , Total Shear Force LDS "
+                        )
+                        fp.write(
+                            ", Press + Shear Force L , Press + Shear Force D , Press + Shear Force Side , Total Press + Shear Force LDS "
+                        )
+                    if press_LDS_coeff_list:
+                        fp.write(
+                            ", Lift Coeff Press  , Drag Coeff Press , Side Coeff Press , Total Coeff Press "
+                        )
+                    if shear_LDS_coeff_list:
+                        fp.write(
+                            ", Lift Coeff Shear  , Drag Coeff Shear , Side Coeff Shear , Coeff Shear LDS Total,"
+                        )
+                        fp.write(
+                            "Coeff Press + Shear L , Coeff Press + Shear D , Coeff Press + Shear Side , Coeff Press + Shear LDS Total"
+                        )
                     fp.write("\n")
-                #  FIX ME keep track of and write out totals here when loop is done on last line?
-                fp.close()
-                return True
-            else:
-                self.ensight.int_message("Error opening filename: '{}'".format(filename),1)
-                return False
+                    #
+                    #  Loop through and write out the vals
+                    #
+                    for ii in range(len(press_force_list)):
+                        fp.write(
+                            str(original_part_selection_list[ii].PARTNUMBER)
+                            + " , "
+                            + original_part_selection_list[ii].DESCRIPTION
+                            + " , "
+                        )
+                        #
+                        # pressure force components then magnitude
+                        #
+                        for jj in range(3):
+                            fp.write(str(press_force_list[ii][jj]))
+                            fp.write(" , ")
+                        fp.write(str(vec_mag(press_force_list[ii][:3])))  # magnitude of Fx, Fy, Fz
+                        if frames:
+                            fp.write(" , ")
+                            for jj in range(3):
+                                fp.write(str(press_force_list[ii][jj + 3]))
+                                fp.write(" , ")
+                            fp.write(
+                                str(vec_mag(press_force_list[ii][3:]))
+                            )  # magnitude of Cyl Fr, Ft, Fa
+                        #
+                        # shear force components then magnitude
+                        #
+                        if shear_force_list:
+                            fp.write(" , ")
+                            for jj in range(3):
+                                fp.write(str(shear_force_list[ii][jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(shear_force_list[ii][:3])))
+                            if frames:
+                                fp.write(" , ")
+                                for jj in range(3):
+                                    fp.write(str(shear_force_list[ii][jj + 3]))
+                                    fp.write(" , ")
+                                fp.write(str(vec_mag(shear_force_list[ii][3:])))
+                            fp.write(" , ")
+                            # sum of pressure and shear forces components then magnitude
+                            for jj in range(3):
+                                temp_list[jj] = press_force_list[ii][jj] + shear_force_list[ii][jj]
+                                fp.write(str(temp_list[jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(temp_list[:3])))
+                            if frames:
+                                fp.write(" , ")
+                                for jj in range(3):
+                                    temp_list[jj] = (
+                                        press_force_list[ii][jj + 3] + shear_force_list[ii][jj + 3]
+                                    )
+                                    fp.write(str(temp_list[jj]))
+                                    fp.write(" , ")
+                                fp.write(str(vec_mag(temp_list[:3])))
+
+                        #
+                        # Coefficient of pressure force components then magnitude
+                        #
+                        if press_coeff_list:
+                            fp.write(" , ")
+                            for jj in range(3):
+                                fp.write(str(press_coeff_list[ii][jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(press_coeff_list[ii][:3])))
+                            if frames:
+                                fp.write(" , ")
+                                for jj in range(3):
+                                    fp.write(str(press_coeff_list[ii][jj + 3]))
+                                    fp.write(" , ")
+                                fp.write(str(vec_mag(press_coeff_list[ii][3:])))
+                        #
+                        # Coefficient shear force components then magnitude
+                        #
+                        if shear_coeff_list is not None and press_coeff_list is not None:
+                            fp.write(" , ")
+                            for jj in range(3):
+                                fp.write(str(shear_coeff_list[ii][jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(shear_coeff_list[ii][:3])))
+                            fp.write(" , ")
+                            if frames:
+                                for jj in range(3):
+                                    fp.write(str(shear_coeff_list[ii][jj + 3]))
+                                    fp.write(" , ")
+                                fp.write(str(vec_mag(shear_coeff_list[ii][3:])))
+                                fp.write(" , ")
+                            # sum of pressure and shear Coefficient components then magnitude
+                            for jj in range(3):
+                                temp_list[jj] = press_coeff_list[ii][jj] + shear_coeff_list[ii][jj]
+                                fp.write(str(temp_list[jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(temp_list)))
+                            if frames:
+                                fp.write(" , ")
+                                for jj in range(3):
+                                    temp_list[jj] = (
+                                        press_coeff_list[ii][jj + 3] + shear_coeff_list[ii][jj + 3]
+                                    )
+                                    fp.write(str(temp_list[jj]))
+                                    fp.write(" , ")
+                                fp.write(str(vec_mag(temp_list)))
+                            fp.write(" , ")
+                        #
+                        # Lift, Drag and Side Force
+                        # No cylindrical stuff here
+                        # LDS pressure force components then magnitude
+                        #
+                        if press_LDS_force_list:
+                            for jj in range(3):
+                                fp.write(str(press_LDS_force_list[ii][jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(press_LDS_force_list[ii][:3])))
+                            fp.write(" , ")
+                        # LDS shear force components then magnitude
+                        if shear_LDS_force_list is not None and press_LDS_force_list is not None:
+                            for jj in range(3):
+                                fp.write(str(shear_LDS_force_list[ii][jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(shear_LDS_force_list[ii][:3])))
+                            fp.write(" , ")
+                            # LDS sum of pressure and shear forces components then magnitude
+                            for jj in range(3):
+                                temp_list[jj] = (
+                                    press_LDS_force_list[ii][jj] + shear_LDS_force_list[ii][jj]
+                                )
+                                fp.write(str(temp_list[jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(temp_list)))
+                            fp.write(" , ")
+                        # LDS Coefficient of pressure force components then magnitude
+                        if press_LDS_coeff_list:
+                            for jj in range(3):
+                                fp.write(str(press_LDS_coeff_list[ii][jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(press_LDS_coeff_list[ii][:3])))
+                            fp.write(" , ")
+                        # LDS Coefficient shear force components then magnitude
+                        if shear_LDS_coeff_list is not None and press_LDS_coeff_list is not None:
+                            for jj in range(3):
+                                fp.write(str(shear_LDS_coeff_list[ii][jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(shear_LDS_coeff_list[ii][:3])))
+                            fp.write(" , ")
+                            # LDS sum of pressure and shear Coefficient components then magnitude
+                            for jj in range(3):
+                                temp_list[jj] = (
+                                    press_LDS_coeff_list[ii][jj] + shear_LDS_coeff_list[ii][jj]
+                                )
+                                fp.write(str(temp_list[jj]))
+                                fp.write(" , ")
+                            fp.write(str(vec_mag(temp_list)))
+                        fp.write("\n")
+                    #  FIX ME keep track of and write out totals here when loop is done on last line?
+                    fp.close()
+                    return True
+            except IOError:
+                raise RuntimeError(
+                    "Error Failed to open output csv filename for writing '" + filename + "'"
+                )
+        raise RuntimeError("Error no pressure force list to write out")
+
+    @staticmethod
+    def _force_coeffs(
+        Forces: List[float], area_ref: float, vel_ref: float, dens_ref: float
+    ) -> List[float]:
+        """Compute the force coefficients for the input list of forces
+
+        Parameters
+        ----------
+
+        Forces: list
+            A list of force values to compute the coefficients for
+        area_ref: float
+            the reference area value for the coefficients computation
+        vel_ref: float
+            the reference velocity magnitude value for the coefficients computation
+        dens_ref: float
+            the reference velocity magnitude value for the coefficients computation
+
+        Returns
+        -------
+        list
+            The list of force coefficients computed
+        """
+        coeffs = []
+        qS = area_ref * vel_ref * vel_ref * dens_ref / 2.0
+        if qS > 0:
+            for ff in Forces:
+                coeffs.append(ff / qS)
         else:
-            self.ensight.int_message("Error no pressure force list to write out",1)
-            return False
+            coeffs = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        return coeffs
+
+    @staticmethod
+    def _get_up_vec(up_str: str) -> np.array:
+        """
+        Convert the up_vector string to the actual components
+
+        Parameters
+        ----------
+        up_str: str
+            the up_vector string
+
+        Returns
+        -------
+        numpy.array
+            The up vector components as a numpy array
+        """
+        if up_str == "+X":
+            up_vec = [1.0, 0.0, 0.0]
+        elif up_str == "+Y":
+            up_vec = [0.0, 1.0, 0.0]
+        elif up_str == "+Z":
+            up_vec = [0.0, 0.0, 1.0]
+        elif up_str == "-X":
+            up_vec = [-1.0, 0.0, 0.0]
+        elif up_str == "-Y":
+            up_vec = [0.0, -1.0, 0.0]
+        elif up_str == "-Z":
+            up_vec = [0.0, 0.0, -1.0]
+        else:
+            raise RuntimeError(
+                f"Up vector {up_str} not allowed. It can only be +X, +Y, +Z, -X, -Y, -Z."
+            )
+        return np.array(up_vec)
+
+    @staticmethod
+    def _lds_forces(
+        f_np_vec: np.array, lift_vec: np.array, drag_vec: np.array, side_vec: np.array
+    ) -> List[float]:
+        """
+        Compute the lift, drag and side force components for the input vector of forces
+
+        Parameters
+        ----------
+        f_np_vec: numpy.array
+            the numpy array representing the force vector in the X,Y,Z directions of the model
+        lift_vec: numpy.array
+            a numpy array representing the lift direction in the X,Y,Z space
+        drag_vec: numpy.array
+            a numpy array representing the drag direction in the X,Y,Z space
+        side_vec: numpy.array
+            a numpy array representing the side force direction in the X,Y,Z space
+
+        Returns
+        -------
+        list:
+            the computed lift, drag and side force component values
+        """
+        lf = np.dot(f_np_vec[:3], lift_vec)
+        df = np.dot(f_np_vec[:3], drag_vec)
+        sf = np.dot(f_np_vec[:3], side_vec)
+        return [lf, df, sf]
+
+    SHEAR_VAR_TYPE_STRESS = 0
+    SHEAR_VAR_TYPE_FORCE = 1
+    UP_VECTOR_PLUS_X = "+X"
+    UP_VECTOR_PLUS_Y = "+Y"
+    UP_VECTOR_PLUS_Z = "+Z"
+    UP_VECTOR_MINUS_X = "-X"
+    UP_VECTOR_MINUS_Y = "-Y"
+    UP_VECTOR_MINUS_Z = "-Z"
+
+    def compute_forces(
+        self,
+        pobj_list: Optional[List[Union[str, int, "ENS_PART"]]] = None,
+        press_var_obj: Optional[Union["ENS_VAR", str, int]] = None,
+        shear_var_obj: Optional[Union["ENS_VAR", str, int]] = None,
+        shear_var_type: Optional[int] = None,
+        area_ref: Optional[float] = None,
+        density_ref: Optional[float] = None,
+        velocity_x_ref: Optional[float] = None,
+        velocity_y_ref: Optional[float] = None,
+        velocity_z_ref: Optional[float] = None,
+        up_vector: Optional[str] = None,
+        export_filename: Optional[str] = None,
+        frame_index: Optional[int] = 0,
+    ) -> Optional[Dict[str, Dict[str, List[float]]]]:
+        """
+        Compute the force values for the current model.
+        During the force computation process, several intermediate EnSight variables are computed.
+        These can always be retrieved for later use.
+        If area_ref, density_ref, velocity_x_ref, velocity_y_ref and velocity_z_ref are supplied,
+        also the normalized forces will be computed.
+        If velocity_x_ref, velocity_y_ref, velocity_z_ref and up_vector are supplied, also the
+        lift, drag and side components of the force will be computed. Eventually, also the normalized
+        lift, drag and side force components are computed if also area_ref and density_ref are supplied.
+        The forces are returned in a dictionary, which will split the force values in pressure, shear, normalized pressure,
+        normalized shear, lds pressure, lds shear, normalized lds pressure and normalized lds shear components,
+        populated depending on the input (lds stands for lift, drag and side components). They can optionatally be
+        saved into a .csv file, which will also report the total values for each group.
+
+        Parameters
+        ----------
+        pobj_list: list
+            The list of part objects to compute the forces on. It can either be a list of names
+            a list of IDs (integers or strings) or directly a list of ENS_PART objects.
+            The list must contain 2D surfaces.
+        press_var_obj: str, ENS_VAR or int
+            The variable to use for the pressure force computation. It can be supplied as variable name,
+            variable ID or ENS_VAR object. It must be a scalar.
+        shear_var_obj: str, ENS_VAR or int
+            The variable to use for the shear force computation. It can be supplied as variable name,
+            variable ID or ENS_VAR object. It must be a vector.
+        shear_var_type: int
+            The kind of shear variable supplied. It can be:
+
+            ===================== ========================================================
+            Name                  Shear variable type
+            ===================== ========================================================
+            SHEAR_VAR_TYPE_STRESS The variable represents the shear stresses distribution
+            SHEAR_VAR_TYPE_FORCE  The variable represents the shear forces distribution
+            ===================== ========================================================
+
+            If not supplied, it will be defaulted to SHEAR_VAR_TYPE_STRESS
+        area_ref: float
+            the area reference value for the force coefficients computation
+        density_ref: float
+            the area reference value for the force coefficients computation
+        velocity_x_ref: float
+            the X velocity reference component. Needed For the coefficients computation and/or the
+            lift/drag/side components computation. The X direction is the X direction for the model.
+        velocity_y_ref: float
+            the Y velocity reference component. Needed For the coefficients computation and/or the
+            lift/drag/side components computation. The Y direction is the Y direction for the model.
+        velocity_z_ref: float
+            the Z velocity reference component. Needed For the coefficients computation and/or the
+            lift/drag/side components computation. The Z direction is the Z direction for the model.
+        up_vector: str
+            Define the "up vector" for the lift/drag/side decomposition. It can be:
+            ================== =================
+            Name               Up vector value
+            ================== =================
+            UP_VECTOR_PLUS_X   +X
+            UP_VECTOR_PLUS_Y   +Y
+            UP_VECTOR_PLUS_Z   +Z
+            UP_VECTOR_MINUS_X  -X
+            UP_VECTOR_MINUS_Y  -Y
+            UP_VECTOR_MINUS_Z  -Z
+            ================== =================
+
+            If not provided, it will default to +Z
+        export_filename: str
+            The filename for the export file. If not provided, not file will be exported.
+            The file will be exported relative to the PyEnSight session, not to the EnSight session.
+        frame_index: int
+            The eventual frame index on which to compute the cylindrical components of the forces.
+            If not provided, the cylindrical components won't be computed.
+
+        Returns
+        -------
+        dict:
+            A dictionary containing all the forces computed, split by force kind and part name
+        """
+        if not frame_index:
+            frame_index = 0
+        if not shear_var_type:
+            shear_var_type = self.SHEAR_VAR_TYPE_STRESS
+        shear_map = {
+            self.SHEAR_VAR_TYPE_STRESS: "Shear stress",
+            self.SHEAR_VAR_TYPE_FORCE: "Shear force",
+        }
+        if not up_vector:
+            up_vector = self.UP_VECTOR_PLUS_Z
+        _pobj_list = self.ensight.utils.parts.select_parts(pobj_list)
+        computed_press_forces: List[List[float]] = []
+        computed_shear_forces: List[List[float]] = []
+        computed_press_force_coeffs: List[List[float]] = []
+        computed_shear_force_coeffs: List[List[float]] = []
+        computed_press_forces_lds: List[List[float]] = []
+        computed_shear_forces_lds: List[List[float]] = []
+        computed_press_forces_lds_coeffs: List[List[float]] = []
+        computed_shear_forces_lds_coeffs: List[List[float]] = []
+        if press_var_obj:
+            success = self._press_force_xyz_rtz(
+                pobj_list=pobj_list, press_var_obj=press_var_obj, frame_index=frame_index
+            )
+            if not success:
+                return None
+            temp = self._sum_pressure_forces_xyz_rtz(pobj_list=pobj_list, frame_index=frame_index)
+            if not temp:
+                return None
+            computed_press_forces = temp.copy()
+        if shear_var_obj:
+            success = self._shear_force_xyz_rtz(
+                pobj_list=pobj_list,
+                shear_var_obj=shear_var_obj,
+                shear_or_force_flag=shear_map.get(shear_var_type),
+                frame_index=frame_index,
+            )
+            if not success:
+                return None
+            temp = self._sum_shear_forces_xyz_rtz(pobj_list=pobj_list, frame_index=frame_index)
+            if not temp:
+                return None
+            computed_shear_forces = temp.copy()
+        coeffs_computation = all(
+            [
+                x is not None
+                for x in [area_ref, velocity_x_ref, velocity_y_ref, velocity_z_ref, density_ref]
+            ]
+        )
+        # Just making mypy happy
+        if (
+            coeffs_computation
+            and velocity_x_ref is not None
+            and velocity_y_ref is not None
+            and velocity_z_ref is not None
+            and area_ref is not None
+            and density_ref is not None
+        ):
+            _vec_mag = vec_mag([velocity_x_ref, velocity_y_ref, velocity_z_ref])
+            # We need to compute the force coeffs
+            if computed_press_forces:
+                for part_force in computed_press_forces:
+                    computed_press_force_coeffs.append(
+                        self._force_coeffs(part_force, area_ref, _vec_mag, density_ref)
+                    )
+            if computed_shear_forces:
+                for part_force in computed_shear_forces:
+                    computed_shear_force_coeffs.append(
+                        self._force_coeffs(part_force, area_ref, _vec_mag, density_ref)
+                    )
+        lds = all(
+            [x is not None for x in [up_vector, velocity_x_ref, velocity_y_ref, velocity_z_ref]]
+        )
+        if lds:
+            temp_np_vec = np.array([velocity_x_ref, velocity_y_ref, velocity_z_ref])
+            drag_vec = temp_np_vec / np.sqrt(np.dot(temp_np_vec, temp_np_vec))
+            up_vec = self._get_up_vec(up_vector)
+            temp_np_vec = np.cross(drag_vec, up_vec)
+            side_vec = temp_np_vec / np.sqrt(np.dot(temp_np_vec, temp_np_vec))
+            # Lift vec normalized
+            temp_np_vec = np.cross(side_vec, drag_vec)
+            lift_vec = temp_np_vec / np.sqrt(np.dot(temp_np_vec, temp_np_vec))
+            if computed_press_forces:
+                for part_force in computed_press_forces:
+                    computed_press_forces_lds.append(
+                        self._lds_forces(np.array(part_force), lift_vec, drag_vec, side_vec)
+                    )
+            if computed_shear_forces:
+                for part_force in computed_shear_forces:
+                    computed_shear_forces_lds.append(
+                        self._lds_forces(np.array(part_force), lift_vec, drag_vec, side_vec)
+                    )
+            if coeffs_computation:
+                if computed_press_force_coeffs:
+                    for part_force in computed_press_force_coeffs:
+                        computed_press_forces_lds_coeffs.append(
+                            self._lds_forces(np.array(part_force), lift_vec, drag_vec, side_vec)
+                        )
+                if computed_shear_force_coeffs:
+                    for part_force in computed_shear_force_coeffs:
+                        computed_shear_forces_lds_coeffs.append(
+                            self._lds_forces(np.array(part_force), lift_vec, drag_vec, side_vec)
+                        )
+        if export_filename is not None and pobj_list is not None:
+            press_varname = None
+            shear_varname = None
+            if press_var_obj:
+                _press_var_id = convert_variable(self.ensight, press_var_obj)
+                if _press_var_id:
+                    press_varnames = [
+                        v for v in self.ensight.objs.core.VARIABLES if v.ID == _press_var_id
+                    ]
+                    if press_varnames:
+                        press_varname = str(press_varnames[0].DESCRIPTION)
+            if shear_var_obj:
+                _shear_var_id = convert_variable(self.ensight, shear_var_obj)
+                if _shear_var_id:
+                    shear_varnames = [
+                        v for v in self.ensight.objs.core.VARIABLES if v.ID == _press_var_id
+                    ]
+                    if shear_varnames:
+                        shear_varname = str(shear_varnames[0].DESCRIPTION)
+            params = {}
+            if press_varname:
+                params["press_varname"] = press_varname
+            if shear_varname:
+                params["shear_varname"] = shear_varname
+            if shear_var_type is not None:
+                value = shear_map.get(shear_var_type)
+                if value:
+                    params["shear_vartype"] = value
+            if area_ref:
+                params["Area_ref"] = str(area_ref)
+            if density_ref:
+                params["Dens_ref"] = str(density_ref)
+            if velocity_x_ref:
+                params["Vx_ref"] = str(velocity_x_ref)
+            if velocity_y_ref:
+                params["Vy_ref"] = str(velocity_y_ref)
+            if velocity_z_ref:
+                params["Vz_ref"] = str(velocity_z_ref)
+            if up_vector:
+                params["up_vector"] = up_vector
+            if frame_index > 0:
+                params["frame_index"] = str(frame_index)
+
+            self._write_out_force_data(
+                export_filename,
+                _pobj_list,
+                params=params,
+                press_force_list=computed_press_forces,
+                shear_force_list=computed_shear_forces,
+                press_coeff_list=computed_press_force_coeffs,
+                shear_coeff_list=computed_shear_force_coeffs,
+                press_LDS_force_list=computed_press_forces_lds,
+                shear_LDS_force_list=computed_shear_forces_lds,
+                press_LDS_coeff_list=computed_press_forces_lds_coeffs,
+                shear_LDS_coeff_list=computed_shear_forces_lds_coeffs,
+            )
+        return {
+            "pressure_forces": {
+                p.DESCRIPTION: computed_press_forces[idx]
+                for idx, p in enumerate(_pobj_list)
+                if idx < len(computed_press_forces)
+            },
+            "shear_forces": {
+                p.DESCRIPTION: computed_shear_forces[idx]
+                for idx, p in enumerate(_pobj_list)
+                if idx < len(computed_shear_forces)
+            },
+            "normalized_pressure_forces": {
+                p.DESCRIPTION: computed_press_force_coeffs[idx]
+                for idx, p in enumerate(_pobj_list)
+                if idx < len(computed_press_force_coeffs)
+            },
+            "normalized_shear_forces": {
+                p.DESCRIPTION: computed_shear_force_coeffs[idx]
+                for idx, p in enumerate(_pobj_list)
+                if idx < len(computed_shear_force_coeffs)
+            },
+            "pressure_forces_lds_direction": {
+                p.DESCRIPTION: computed_press_forces_lds[idx]
+                for idx, p in enumerate(_pobj_list)
+                if idx < len(computed_press_forces_lds)
+            },
+            "shear_forces_lds_direction": {
+                p.DESCRIPTION: computed_shear_forces_lds[idx]
+                for idx, p in enumerate(_pobj_list)
+                if idx < len(computed_shear_forces_lds)
+            },
+            "normalized_pressure_forces_lds_direction": {
+                p.DESCRIPTION: computed_press_forces_lds_coeffs[idx]
+                for idx, p in enumerate(_pobj_list)
+                if idx < len(computed_press_forces_lds_coeffs)
+            },
+            "normalized_shear_forces_lds_direction": {
+                p.DESCRIPTION: computed_shear_forces_lds[idx]
+                for idx, p in enumerate(_pobj_list)
+                if idx < len(computed_shear_forces_lds_coeffs)
+            },
+        }

--- a/src/ansys/pyensight/core/utils/variables.py
+++ b/src/ansys/pyensight/core/utils/variables.py
@@ -912,7 +912,7 @@ class Variables:
             new_pres_var_obj = ensvar_values[0]
             press_var_name = new_pres_var_obj.DESCRIPTION
         else:
-            press_var_name = new_pres_var_obj.DESCRIPTION
+            press_var_name = _press_var_obj.DESCRIPTION
 
         #
         # Calculate the Force vector

--- a/src/ansys/pyensight/core/utils/variables.py
+++ b/src/ansys/pyensight/core/utils/variables.py
@@ -1,0 +1,1191 @@
+"""Variables module.
+
+This module provides simplified interface to compute specific variables via PyEnSight
+
+"""
+import numpy as np
+import os
+import math
+from typing import TYPE_CHECKING, Union
+
+try:
+    import ensight
+    from ensight.objs import ens_emitterobj, ensobjlist  # type: ignore
+except ImportError:
+    from ansys.api.pyensight.ens_emitterobj import ens_emitterobj
+    from ansys.pyensight.core.listobj import ensobjlist
+
+if TYPE_CHECKING:
+    from ansys.api.pyensight.ens_var import ENS_VAR
+    from ansys.api.pyensight import ensight_api
+
+#
+#  finds float value vector magnitude
+#
+def vec_mag(inval):
+    if len(inval) == 3:
+        vm = math.sqrt(inval[0]*inval[0] + inval[1]*inval[1] + inval[2]*inval[2])
+    else:
+        vm = 0.0
+    return vm
+
+class Variables:
+    
+    def __init__(self, ensight: Union["ensight_api.ensight", "ensight"]):
+        self.ensight = ensight
+
+#  Checks for the existence of var_name
+#   in the list of variables
+#
+#   FIX ME for many variables speed up!
+#
+    def _check_for_var_elem(self, var_name, pobj_list):
+        vlist = self.ensight.core.VARIABLES.find(var_name)
+        if len(vlist) > 0:
+            var = vlist[0]
+            #  Check to see that selected parts are all
+            #   within the list of parts used to calc var
+            #   if NOT then return None
+            for prt in pobj_list:
+                if prt not in var.PARTS:
+                    return None
+            return var
+        return None
+    
+#
+# IN: var_obj
+# OUT: calcs elemental from nodal variable and 
+#        returns list containing var object or empty list if err.
+#        Does nothing and returns input var name
+#        if already elemental.
+#
+#   elemental_var_list = move_var_to_elem( original_part_selection_list, shear_var_list[0])
+#
+#   Return a list containing the variable object or [ ] if failure 
+#
+    def _move_var_to_elem(self, pobj_list, var_obj):
+        # get the last created var obj to use as a test to see if a new one is created
+        last_var_obj = max(self.ensight.core.VARIABLES)
+        #
+        var_name = var_obj.DESCRIPTION
+        calc_var_name = ""
+        if self.ensight.objs.enums.ENS_VAR_ELEM != var_obj.LOCATION:
+            calc_var_name = "_E"
+            ret_val = self._check_for_var_elem(var_name+calc_var_name, pobj_list)
+            if ret_val == None:
+                print("Calculating elemental variable: {} {}".format(var_name, calc_var_name))
+                self.ensight.utils.parts.select_parts(pobj_list) 
+                calc_string = "(plist," + var_name + ')'
+                per_node_var = var_name + calc_var_name + " = NodeToElem"
+                temp_string = per_node_var + calc_string
+                if 0 != self._calc_var(pobj_list, temp_string):
+                    self.ensight.int_message("Failed to calculate elemental variable",1)
+                    return []
+            else:
+                print("Using elemental variable that already exists: {}".format(ret_val.DESCRIPTION))
+                return [ret_val]
+
+        new_var_obj = max(self.ensight.objs.core.VARIABLES)
+        if new_var_obj != last_var_obj: # a new, elemental one was created!
+            return [new_var_obj]
+        else: # return the input value as a new one wasn't created
+            return [var_obj]
+        
+    #
+#  Calculates a variable
+#   using calc_string in ensight
+#
+#  Returns 0 if successful
+#         non-zero if fail
+#
+    def _calc_var(self, pobj_list=[],calc_string=""):
+        err = -1
+        if len(calc_string) > 0 and len(pobj_list)>0:
+            self.ensight.utils.parts.select_parts(pobj_list)
+            err = self.ensight.variables.evaluate(calc_string) #,record=1)
+            if err != 0:
+                err_string = "Error calculating " + calc_string
+                self.ensight.int_message(err_string,1)
+        return err
+
+#
+#
+# IN:
+#  part object list - A list of ENS_PARTs
+#  var_object -     Must be an elemental variable
+#  shear_or_force_flag = "Shear stress" or "Shear force" depending on the shear variable
+#                        This is obtained from the gui params['shear_vartype']
+#  frame_index - if > 0 then use this frame to calculate cylindrical components in this
+#                        frame
+#
+# OUT:
+#
+#    Creates (or recreates) several intermediate vars:
+#
+#    ENS_Force_Norm
+#
+#    depending on if the shear variable is Force or Stress:
+#    ENS_Force_Dot_prod_Flu_shear_<Force or Stress>_Norm 
+#    ENS_Force_NomalShear<Force or Stress>
+#
+#    ENS_Force_TangentialShear<Force or Stress>
+#
+#    ENS_Force_TangentialShear<Force or Stress>_X
+#    ENS_Force_TangentialShear<Force or Stress>_Y
+#    ENS_Force_TangentialShear<Force or Stress>_Z
+#
+#    if the variable is shear stress
+#       ENS_Force_ElementArea
+#
+#    And finally the shear force components:
+#     ENS_Force_TangentialShearForce_X
+#     ENS_Force_TangentialShearForce_Y
+#     ENS_Force_TangentialShearForce_Z
+#
+#    Now, new in 10.1.6(c), RTZ if more than one frame and chosen frame index exists
+#     ENS_Force_Tan_ShearForce (which is a vector composed of the above components)
+#     ENS_Force_Tan_ShearForce_cyl (which is cylindrical resolved in the frame index coordinate sys)
+#     and the components of the cylindrical vector:
+#      ENS_Force_Tan_ShearForce_R - Radial component
+#      ENS_Force_Tan_ShearForce_T - Theta (angular) component
+#      ENS_Force_Tan_ShearForce_A - Axial (frame index Z) component
+#
+#   WARNING: Each time you call this function, it
+#     overwrites all these EnSight variables.
+#
+#   WARNING: These variable names are the same
+#      as the 10.0 Pressure Force Python Tool
+#
+    def _shear_force_xyz_rtz(self, pobj_list, shear_var_obj, shear_or_force_flag = "Shear stress", frame_index = 0):
+        #  
+        # This pobj_list should contain only 2D parts
+        #
+        if len(pobj_list) < 1:
+            self.ensight.int_message("Error, no part provided",1)
+            return False
+        #
+        # select all parts in list
+        #
+        self.ensight.utils.parts.select_parts(pobj_list)
+        #
+        # can be using shear force or shear stress
+        #
+        if shear_or_force_flag == "Shear stress":
+            stemp_string = "Stress"
+        else:
+            stemp_string = "Force"
+        # create a surface normal vector variable using the 
+        # "Normal" function in the variable calculator.
+        #
+        temp_string = "ENS_Force_Norm = Normal(plist)"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return False
+        #
+        # makes a new elem var if input var is nodal
+        #
+        #
+        if shear_var_obj.LOCATION == self.ensight.objs.enums.ENS_VAR_ELEM:
+            shear_var_name = shear_var_obj.DESCRIPTION
+        else:
+            err_string = "Error shear_force_xyz_rtz: variable {} is not an elemental variable".format(shear_var_obj.DESCRIPTION)
+            self.ensight.int_message(err_string,1)
+            return False
+        
+        #
+        # Compute the Dot product of the Vector Normal and the FluidShearVector
+        #
+        temp_string = "ENS_Force_Dot_prod_Flu_shear_"+ stemp_string +"_Norm = DOT(" + shear_var_name + ",ENS_Force_Norm)"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return False
+        
+        # multiplying this DOT product by the surface normal vector produces 
+        # the normal component of the shear stress vector.
+        #
+        temp_string = "ENS_Force_NomalShear"+ stemp_string +" = ENS_Force_Dot_prod_Flu_shear_"+ stemp_string +"_Norm*ENS_Force_Norm"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return False
+        #
+        # The tangential component is now computed by subtracting this normal 
+        # component from the shear stress vector, or Vt = V - Vn, 
+        # where V represents the shear stress vector. 
+        #
+        temp_string = "ENS_Force_TangentialShear" + stemp_string + " = " + shear_var_name + "-ENS_Force_NomalShear"+ stemp_string
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return False
+        #
+        # Decompose the TangentialShearStress Vector into its x, y, z component of 
+        # TangentialShearStress_X, TangentialShearStress_Y, and TangentialShearStress_Z
+        temp_string = "ENS_Force_TangentialShear"+ stemp_string +"_X = ENS_Force_TangentialShear"+ stemp_string +"[X]"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return False
+        
+        temp_string = "ENS_Force_TangentialShear"+ stemp_string +"_Y = ENS_Force_TangentialShear"+ stemp_string +"[Y]"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return False
+        
+        temp_string = "ENS_Force_TangentialShear"+ stemp_string +"_Z = ENS_Force_TangentialShear"+ stemp_string +"[Z]"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return False
+        
+        #
+        #
+        # Calculate the Tangential Shear stress forces by multiplying each of the 
+        # Components of the Tangential Shear stress with Element Size scalar.
+        if shear_or_force_flag == "Shear stress":
+            #
+            # Calculate the element area Scalar using the "EleSize function in the Variable Calculator
+            #
+            temp_string = "ENS_Force_ElementArea = EleSize(plist)"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+            
+            temp_string = "ENS_Force_Tan_ShearForce_X = ENS_Force_TangentialShear"+ stemp_string +"_X*ENS_Force_ElementArea"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+            
+            temp_string = "ENS_Force_Tan_ShearForce_Y = ENS_Force_TangentialShear"+ stemp_string +"_Y*ENS_Force_ElementArea"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+            
+            temp_string = "ENS_Force_Tan_ShearForce_Z = ENS_Force_TangentialShear"+ stemp_string +"_Z*ENS_Force_ElementArea"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+            
+        else:
+            temp_string = "ENS_Force_Tan_ShearForce_X = ENS_Force_TangentialShear"+ stemp_string +"_X"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+        
+            temp_string = "ENS_Force_Tan_ShearForce_Y = ENS_Force_TangentialShear"+ stemp_string +"_Y"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+        
+            temp_string = "ENS_Force_Tan_ShearForce_Z = ENS_Force_TangentialShear"+ stemp_string +"_Z"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+        
+        if frame_index > 0 and frame_index < len(self.ensight.objs.core.FRAMES):
+            # remake the vector
+            temp_string = "ENS_Force_Tan_ShearForce = MakeVect(plist, ENS_Force_Tan_ShearForce_X, ENS_Force_Tan_ShearForce_Y, ENS_Force_Tan_ShearForce_Z)"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+            
+            # resolve it in cylindrical coords
+            temp_string = "ENS_Force_Tan_ShearForce_cyl = RectToCyl(plist,ENS_Force_Tan_ShearForce,"+str(frame_index)+")"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return False
+            
+            # Radial, theta , axial
+            temp_string = "ENS_Force_Tan_ShearForce_R  = ENS_Force_Tan_ShearForce_cyl[X]"
+            if 0 != self._calc_var(pobj_list,temp_string):  # radial force
+                return False
+        
+            temp_string = "ENS_Force_Tan_ShearForce_T  = ENS_Force_Tan_ShearForce_cyl[Y]"
+            if 0 != self._calc_var(pobj_list,temp_string): # angular force
+                return False
+        
+            temp_string = "ENS_Force_Tan_ShearForce_A  = ENS_Force_Tan_ShearForce_cyl[Z]"
+            if 0 != self._calc_var(pobj_list,temp_string): # axial force        
+                return False
+        return True
+
+    #
+    #  Uses the stat moment calc function to sum the shear forces for this list of parts
+    #   resulting in a per part constant and a case constant as of 10.2.0(d) for each force component
+    #   IN:
+    #     pobj_list - A list of ENS_PART(s)
+    #
+    #     frame_index = If 0 then do not calc RTZ cylindrical net forces
+    #                 otherwise calculate the net forces in Radial, Theta, and Axial
+    #    
+    #    OUT
+    #    calculates the net shear force per part constant using all parts
+    #     in the list and creates three or six per part constants:
+    #      ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z
+    #
+    #    Now, new in 10.1.6(c), RTZ if more than one frame and chosen frame index exists
+    #     if frame_index > 0, then calc net force using the cylindrical forces in the
+    #     frame_index reference system adn in 10.2.0(d) three are per part constants
+    #
+    #       ENS_Force_Net_Tan_ShearForce_R - net shear force in the radial direction
+    #       ENS_Force_Net_Tan_ShearForce_T - net shear force in the angular (theta) direction
+    #       ENS_Force_Net_Tan_ShearForce_A - net shear force in the axial (frame index Z) direction
+    #
+    #    Returns:
+    #       if frame_index > 0 and frame exists then returns forces for each part in the list:
+    #          ( [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z,  ENS_Force_Net_Tan_ShearForce_R, ENS_Force_Net_Tan_ShearForce_T, ENS_Force_Net_Tan_ShearForce_A  ]  ,
+    #            [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z , ENS_Force_Net_Tan_ShearForce_R, ENS_Force_Net_Tan_ShearForce_T, ENS_Force_Net_Tan_ShearForce_A  ]  ,
+    #            [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z, ENS_Force_Net_Tan_ShearForce_R, ENS_Force_Net_Tan_ShearForce_T, ENS_Force_Net_Tan_ShearForce_A  ]  , ...)
+    #       else:
+    #          ( [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z , 0.0  , 0.0  , 0.0  ]  ,
+    #          ( [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z , 0.0  , 0.0  , 0.0  ]  ,
+    #          ( [ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_Z , 0.0  , 0.0  , 0.0  ]  , ...)
+    #       ERROR:
+    #              [ ] empty list if error calculating vars or getting constant values
+    #
+    def _sum_shear_forces_xyz_rtz(self, pobj_list, frame_index = -1):
+        #  
+        # This pobj_list should contain only 2D parts
+        #
+        #
+        fcn_name = "sum_shear_forces_xyz_rtz"
+        if len(pobj_list) < 1:
+            self.ensight.int_message("Error, no part provided",1)
+            return []
+        #
+        # select all parts in list
+        #
+        self.ensight.utils.parts.select_parts(pobj_list)
+        #
+        # Sum up each of the Tangential Shear Stress Force Components to get Constants in each
+        # of the directions ENS_Force_Net_Tan_Shear_X, ENS_Force_Net_Tan_Shear_Y, ENS_Force_Net_Tan_Shear_X
+        #
+        #
+        temp_string = "ENS_Force_Net_Tan_ShearForce_X = StatMoment(plist,ENS_Force_Tan_ShearForce_X, 0, Compute_Per_part)"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+            ensight.int_message(err_string,1)
+            return []
+        
+        temp_string = "ENS_Force_Net_Tan_ShearForce_Y = StatMoment(plist,ENS_Force_Tan_ShearForce_Y, 0, Compute_Per_part)"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+            self.ensight.int_message(err_string,1)
+            return []
+    
+        temp_string = "ENS_Force_Net_Tan_ShearForce_Z = StatMoment(plist,ENS_Force_Tan_ShearForce_Z, 0, Compute_Per_part)"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+            self.ensight.int_message(err_string,1)
+            return []
+        #
+        # get the 3 constant force values XYZ
+        # 10.1.6(b) use ens_utils, 10.2.0(d) Now gets all the per part constants in a list
+        Fx = self.get_const_val("ENS_Force_Net_Tan_ShearForce_X",pobj_list)
+        Fy = self.get_const_val("ENS_Force_Net_Tan_ShearForce_Y",pobj_list)
+        Fz = self.get_const_val("ENS_Force_Net_Tan_ShearForce_Z",pobj_list)
+        #
+        # Calculate the Total Shear force X, Y, and Z , 10.2.0(d) now case constant variable
+        #  Totals are a case constants. We don't do anything with these vars
+        #   they are calc'd to give the user the totals.
+        #
+        temp_string = "ENS_Force_Total_Net_Tan_ShearForce_X = StatMoment(plist,ENS_Force_Tan_ShearForce_X, 0, Compute_Per_case)"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+            self.ensight.int_message(err_string,1)
+            return []
+        
+        temp_string = "ENS_Force_Total_Net_Tan_ShearForce_Y = StatMoment(plist,ENS_Force_Tan_ShearForce_Y, 0, Compute_Per_case)"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+            self.ensight.int_message(err_string,1)
+            return []
+    
+        temp_string = "ENS_Force_Total_Net_Tan_ShearForce_Z = StatMoment(plist,ENS_Force_Tan_ShearForce_Z, 0, Compute_Per_case)"
+        if 0 != self._calc_var(pobj_list,temp_string):
+            err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+            self.ensight.int_message(err_string,1)
+            return []
+        #
+        #   
+        #
+        if frame_index > 0 and frame_index < len(self.ensight.objs.core.FRAMES):
+            temp_string = "ENS_Force_Net_Tan_ShearForce_R = StatMoment(plist,ENS_Force_Tan_ShearForce_R,0, Compute_Per_part)"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+                self.ensight.int_message(err_string,1)
+                return []
+    
+            temp_string = "ENS_Force_Net_Tan_ShearForce_T = StatMoment(plist,ENS_Force_Tan_ShearForce_T,0, Compute_Per_part)"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+                self.ensight.int_message(err_string,1)
+                return []
+    
+            temp_string = "ENS_Force_Net_Tan_ShearForce_A = StatMoment(plist,ENS_Force_Tan_ShearForce_A,0, Compute_Per_part)"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+                self.ensight.int_message(err_string,1)
+                return []
+            #
+            # Totals
+            #
+            temp_string = "ENS_Force_Total_Net_Tan_ShearForce_R = StatMoment(plist,ENS_Force_Tan_ShearForce_R,0, Compute_Per_case)"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+                self.ensight.int_message(err_string,1)
+                return []
+    
+            temp_string = "ENS_Force_Total_Net_Tan_ShearForce_T = StatMoment(plist,ENS_Force_Tan_ShearForce_T,0, Compute_Per_case)"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+                self.ensight.int_message(err_string,1)
+                return []
+    
+            temp_string = "ENS_Force_Total_Net_Tan_ShearForce_A = StatMoment(plist,ENS_Force_Tan_ShearForce_A,0, Compute_Per_case)"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                err_string = "Error, failed to calculate a variable in {}".format(fcn_name)
+                self.ensight.int_message(err_string,1)
+                return []
+            #
+            # get the 3 constant force values Radial, Theta, Axial
+            # new use ens_utils 10.1.6(b)
+            Fr = self.get_const_val("ENS_Force_Net_Tan_ShearForce_R",pobj_list)
+            Ft = self.get_const_val("ENS_Force_Net_Tan_ShearForce_T",pobj_list)
+            Fa = self.get_const_val("ENS_Force_Net_Tan_ShearForce_A",pobj_list)
+            if Fr != None and Fa != None and Ft != None and Fx != None and Fy != None and Fz != None: 
+                ret_val = []
+                for ii in range(len(pobj_list)):
+                    ret_val.append([Fx[ii],Fy[ii],Fz[ii],Fr[ii],Ft[ii],Fa[ii]])
+                return ret_val            
+            else:
+                self.ensight.int_message("Error getting ENS_Force_Net_Tan_ShearForce_R, T and/or A",1)
+                return []
+        else: # Only one frame or user picked frame 0 (None) for cylindrical frame calc
+            if  Fx != None and Fy != None and Fz != None:
+                ret_val = []
+                for ii in range(len(pobj_list)):
+                    ret_val.append([Fx[ii],Fy[ii],Fz[ii],0.0,0.0,0.0])
+                return ret_val
+            else:
+                self.ensight.int_message("Error getting Fx, Fy, and/or Fz Shear Net force per part constant values",1)
+                return []            
+
+    
+    
+    #
+    # Returns constant or (new in 10.2) per part constant var objects
+    #
+    def get_const_vars(self, var_type=None):
+        """
+        Get all constant OR per part constant variables
+
+        Parameters
+        ----------
+        var_type - enums.ENS_VAR_CONSTANT (default)
+            or     enums.ENS_VAR_CONSTANT_PER_PART (new in 10.2)
+
+        Return
+        List containing ENS_VAR objects
+
+        """
+        if not var_type:
+            var_type = self.ensight.objs.enums.ENS_VAR_CONSTANT
+        d = {self.ensight.objs.enums.VARTYPE: var_type}
+        return(self.ensight.objs.core.find_objs(self.ensight.objs.core.VARIABLES,filter=d))
+    #
+    # Returns list constant or (new in 10.2) per part constant var names
+    #
+    def get_const_var_names(self, v_type=None):
+        """
+        Get string names of all constant OR per part constant variables 
+
+        Parameters
+        ----------
+        v_type   - enums.ENS_VAR_CONSTANT (default)
+            or     enums.ENS_VAR_CONSTANT_PER_PART (new in 10.2)
+
+        Return
+        List containing names of constants
+
+        """
+        if not v_type:
+            v_type = self.ensight.objs.enums.ENS_VAR_CONSTANT
+        name_list = []
+        vars = self.get_const_vars(var_type=v_type)
+        for var in vars:
+            name_list.append(var.DESCRIPTION)
+        return(name_list)
+
+    def get_part_id_obj_name(self, plist=None, ret_flag="id"):
+        """
+        input a part or a list of parts and return an id, object, or name
+          or a list of ids, objects, or names.
+        
+        Parameters
+        ----------
+        p_list:
+          1. A list of ENS_PART objects 
+          OR
+          2. A list of int part ids 
+          OR
+          3. A list of strings
+             a. each string is an ID
+             b. each string is exact match for a part name 
+          OR
+          4. A single ENS_PART object 
+          OR
+          5. A single string
+             a. that is a part id OR
+             b. that extactly matches the part DESCRIPTION
+          OR
+          6. a single int that is a part id
+          
+        ret_flag - a string that determines what is returned
+        
+        Return: 
+          - a list as follows
+          A. ret_flag contains "id" -   returns a list of ids (default)
+          B. ret_flag contains "name" - returns a list of part names
+          C. ret_flag contains "obj"  - returns a list of ENS_PARTs      
+          or [ ] if error.    
+        """
+        if not plist:
+            plist = self.ensight.objs.core.PARTS
+        pobj_list = []
+        #
+        #  Basically figure out what plist is, then convert it to a list of ENS_PARTs
+        #
+        if isinstance(plist, self.ensight.objs.ENS_PART) or  isinstance(plist,int) or isinstance(plist,str):
+            p_list = [plist]
+        elif  isinstance(plist, list) or isinstance(plist, self.ensight.objs.ensobjlist):
+            p_list = plist
+        else:
+            print("Unknown type of input var plist {}".format(type(plist)))
+            return []
+        #
+        #  p_list must now be a list
+        #
+        if len(p_list) > 0:
+            if isinstance(p_list[0], self.ensight.objs.ENS_PART): # list of objects assumed consistent
+                for prt in p_list:
+                    pobj_list.append(prt)
+            elif isinstance(p_list[0],int): # list of ints must be part ids
+                for pid in p_list:
+                    d = {self.ensight.objs.enums.PARTNUMBER:pid}
+                    pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS,d)
+                    for prt in pobjs:
+                        pobj_list.append(prt)
+            elif isinstance(p_list[0],str):
+                if p_list[0].isdigit() == False:
+                    for pname in p_list:
+                        d = {self.ensight.objs.enums.DESCRIPTION:pname}
+                        pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS,d)
+                        for prt in pobjs:
+                            pobj_list.append(prt)
+                else: # digits, must be a string list of part ids? 
+                    for pid_str in p_list:
+                        d =  {self.ensight.objs.enums.PARTNUMBER:int(pid_str)}
+                        pobjs = self.ensight.objs.core.find_objs(self.ensight.objs.core.PARTS,d)
+                        for prt in pobjs:
+                            pobj_list.append(prt)
+            else:
+                print("First member is neither ENS_PART, int, nor string")
+                print("{} type= {}".format(p_list[0],type(p_list[0])))
+                print("aborting")
+                pobj_list = []
+        else: # zero length list
+            print("Zero length list")
+            pobj_list = []
+        ret_val = []
+        if pobj_list:
+            for pobj in pobj_list:
+                if ret_flag.lower().find('name') >=0:
+                    ret_val.append(pobj.DESCRIPTION)
+                elif ret_flag.lower().find('obj') >=0:
+                    ret_val.append(pobj)
+                else:
+                    ret_val.append(pobj.PARTNUMBER)
+        else:
+            ret_val = []
+        return ret_val
+
+    def get_const_val(self, cname, part_list=None, undef_none=False):
+        """
+          Return a float value of a variable Case constant at the current timestep,
+             or return a list of values one for each part if a per part constant.
+             
+          Parameters
+          ----------
+          cname - the text name of the constant or ENS_VAR object 
+    
+          part_list - A single ENS_PART, part name, part id, or a list of these
+                      For per part constants this is necessary so if empty, will
+                      be all parts
+    
+          undef_none - if False (default) returns undef value (ensight.Undefined) if var
+                       value is undefined OR
+                       if True, returns None for undefined 
+    
+          Return if a Constant
+                 the float value of a constant
+                 OR
+                 ensight.Undefined if var is undefined and undef_none is False (default)
+                 OR
+                 None if error or if var is undefined and undef_none is True
+    
+                 NEW in 10.2
+                 if a Per part constant returns a list of values, corresponding to
+                 each part in the input part list 
+                  a list of float values if per part constant
+                 OR
+                  a list of float and None values if undef_none is True
+                 OR
+                  [ ] if error
+    
+        """
+        if not part_list:
+            part_list = self.ensight.objs.core.PARTS
+        ens_routine = " 'get_const_val' "
+        const_name = ""
+        #
+        #  error checking
+        #
+        if isinstance(cname,str):
+            if len(cname) > 0:
+                const_name = cname
+                if const_name in self.get_const_var_names(v_type=ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART):
+                    const_type = ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART
+                elif const_name in self.get_const_var_names(v_type=ensight.objs.enums.ENS_VAR_CONSTANT):
+                    const_type = ensight.objs.enums.ENS_VAR_CONSTANT
+                else:
+                    print("Error, {} Constant name {} is not a constant nor a per part constant".format( ens_routine,const_name))
+                    return None
+            else:
+                print("Error, {} must supply a valid constant variable name ".format(ens_routine))
+                return None
+        elif isinstance(cname, self.ensight.objs.ENS_VAR):
+            const_name = cname.DESCRIPTION
+            const_type = cname.VARTYPEENUM
+            if const_type != self.ensight.objs.enums.ENS_VAR_CONSTANT and const_type != self.ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART:
+                print("Error, Variable {} is not a constant nor a per part constant".format(cname))
+                return None
+        else:
+            print("Error, 'get_const_val' Constant name is neither string nor ENS_VAR")
+            return None
+        #
+        #
+        #  Now get it
+        #
+        self.ensight.variables.activate(const_name) # bug fixed 10.1.6(c)
+        
+        if const_type == self.ensight.objs.enums.ENS_VAR_CONSTANT_PER_PART: # new in 10.2
+    
+            if not part_list:
+                part_list = self.ensight.objs.core.PARTS
+    
+            plist = self.get_part_id_obj_name(part_list,'obj')
+            ret_val = []
+            #
+            for prt in plist:
+                if isinstance(prt,ensight.objs.ENS_PART):
+                    val_dict = prt.get_values([const_name])
+                    if val_dict:
+                        val = val_dict[const_name][0]
+                        if undef_none == True and  np.isclose( val , self.ensight.Undefined, rtol=1e-6,atol=1e-16):
+                            ret_val.append(None)
+                        else:
+                            ret_val.append(val)
+                else:
+                    print("Error {} part list must contain a list of only ENS_PARTs".format(ens_routine))
+            return ret_val
+        else: # the legacy way using the interface manual ch 6
+    
+            (val,type_val,scope_val) = self.ensight.ensvariable(const_name)
+    
+            # type = 0 if the value is an integer, 1 if the value is a float and 2 if the value is a string
+            # scope =  -1 if it is a constant computed in EnSight, and
+            #             scope will be >= 0 if a command language global
+            #             (0 if command language global and >0 if local to a file or loop)
+            if scope_val == -1  and type_val == 1: # EnSight constant and float
+                if undef_none == True and  np.isclose( val , self.ensight.Undefined, rtol=1e-6,atol=1e-16):
+                    return None
+                else:
+                    return val
+            else:
+                print("Error, {} return value from ensight.ensvariable indicates it is not a float from an Ensight Constant".format(ens_routine))
+                return None
+
+    #
+    #
+    # IN:
+    #  part object list 
+    #  var_object -     Must be an elemental variable
+    #  frame_index -    if > 0 and frame exists, use that frame to calc cylindrical forces
+    # OUT:
+    #
+    #    Creates (or recreates)
+    #    several intermediate vars:
+    #    ENS_Force_press
+    #    ENS_Force_press_X
+    #    ENS_Force_press_Y
+    #    ENS_Force_press_Z
+    #    if frame index > 0 and less than the number of frames,
+    #       ENS_Force_press_cyl is the conversion of ENS_Force_press to cylindrical coords
+    #       ENS_Force_press_R - Radial component of the pressure force in frame index
+    #       ENS_Force_press_T - Angular (theta)  component of the pressure force in frame index
+    #       ENS_Force_press_A - Axial (z component of chosen frame) of the pressure force 
+    #
+    #   WARNING: Each time you call this function, it
+    #     overwrites all these EnSight variables.
+    #
+    #   WARNING: These variable names are the same
+    #      as the 10.0 Pressure Force Python Tool
+    #
+    #    Return: True if success
+    #            False if error
+    #
+    def _press_force_xyz_rtz(self, pobj_list, press_var_obj, frame_index = 0):
+        #
+        # This pobj_list should contain only 2D parts
+        #
+        if len(pobj_list) < 1:
+            self.ensight.int_message("Error, no part provided",1)
+            return False
+        #
+        # select all parts in list
+        #
+        self.ensight.utils.parts.select_parts(pobj_list)
+        #
+        # makes a new elem var if input var is nodal
+        #
+        if press_var_obj.LOCATION == self.ensight.objs.enums.ENS_VAR_ELEM:
+            press_var_name = press_var_obj.DESCRIPTION
+        else:
+            err_string = "Error press_force_xyz_rtz: variable '{}' is not an elemental variable".format(press_var_obj.DESCRIPTION)
+            self.ensight.int_message(err_string,1)
+            return False
+        #
+        # Calculate the Force vector
+        #
+        calc_string = "(plist," + press_var_name + ')'
+        force_calc_string = 'ENS_Force_press = Force'
+        temp_string = force_calc_string + calc_string
+        if 0 != self._calc_var(pobj_list,temp_string):
+            self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
+            return False
+        #
+        # Calculate the force components
+        #
+        self.ensight.utils.parts.select_parts(pobj_list)
+        temp_string = 'ENS_Force_press_X = ENS_Force_press[X]'
+        if 0 != self._calc_var(pobj_list,temp_string):
+            self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
+            return False
+    
+        temp_string = 'ENS_Force_press_Y = ENS_Force_press[Y]'
+        if 0 != self._calc_var(pobj_list,temp_string):
+            self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
+            return False
+    
+        temp_string = 'ENS_Force_press_Z = ENS_Force_press[Z]'
+        if 0 != self._calc_var(pobj_list,temp_string):
+            self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
+            return False
+        #
+        #  RTZ Cylindrical force
+        #
+        if frame_index > 0 and frame_index < len(self.ensight.objs.core.FRAMES):
+            temp_string = "ENS_Force_press_cyl = RectToCyl(plist,ENS_Force_press,"+ str(frame_index)+")"
+            if 0 != self._calc_var(pobj_list,temp_string):
+                self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
+                return False
+    
+            temp_string = "ENS_Force_press_R = ENS_Force_press_cyl[X]"
+            if 0 != self._calc_var(pobj_list,temp_string):  # radial force
+                self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
+                return False
+    
+            temp_string = "ENS_Force_press_T  = ENS_Force_press_cyl[Y]"
+            if 0 != self._calc_var(pobj_list,temp_string): # angular force
+                self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
+                return False
+    
+            temp_string = "ENS_Force_press_A  = ENS_Force_press_cyl[Z]"
+            if 0 != self._calc_var(pobj_list,temp_string): # axial force        
+                self.ensight.int_message("Error calculating: '"+temp_string+"'",1)
+                return False
+        return True
+
+
+    #
+    #  Uses the stat moment to sum the forces for this list of parts
+    #   resulting in a per part constant and a case constant as of 10.2.0(d)
+    #   IN:
+    #     pobj_list - A list of ENS_PART(s)
+    #
+    #     frame_index = If 0 then do not calc RTZ cylindrical net forces
+    #                 otherwise calculate the net forces in Radial, Theta, and Axial
+    #   OUT:
+    #   calculates net pressure force per part constant using all parts
+    #    in the list and creates three or six per part constants:
+    #      ENS_Force_Net_press_X
+    #      ENS_Force_Net_press_Y
+    #      ENS_Force_Net_press_Z
+    #
+    #      if frame_index > 0, then calc net force using the
+    #       cylindrical forces in the frame_index reference system three additional
+    #       per part constants
+    #
+    #        ENS_Force_Net_press_R - net pressure force in the radial direction
+    #        ENS_Force_Net_press_T - net pressure force in the theta angular direction
+    #        ENS_Force_Net_press_A - net pressure force in the axial direction 
+    #
+    #   Returns:
+    #      if frame_index > 0 and frame exists then returns forces for each part in the list:
+    #         ( [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, ENS_Force_Net_press_R, ENS_Force_Net_press_T, ENS_Force_Net_press_A ] ,
+    #           [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, ENS_Force_Net_press_R, ENS_Force_Net_press_T, ENS_Force_Net_press_A ] ,
+    #           [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, ENS_Force_Net_press_R, ENS_Force_Net_press_T, ENS_Force_Net_press_A ] , ... )
+    #      else:
+    #         ( [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, 0.0, 0.0, 0.0] ,
+    #           [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, 0.0, 0.0, 0.0] ,
+    #           [ ENS_Force_Net_press_X, ENS_Force_Net_press_Y, ENS_Force_Net_press_Z, 0.0, 0.0, 0.0] , ... )
+    #      ERROR:
+    #         [ ] if error calculating variables or getting back constant values
+    #
+    #
+    def sum_pressure_forces_xyz_rtz(self, pobj_list, frame_index=0):
+        #  
+        # This pobj_list should contain only 2D parts
+        #
+        if len(pobj_list)<1 :
+            self.ensight.int_message("Error, no part provided",1)
+            return []
+        #
+        # Select the part(s) in the list
+        # ensight.variables.evaluate("ENS_Force_Net_press_Y = StatMoment(plist,pressure,0,Compute_Per_part)")
+        self.ensight.utils.parts.select_parts(pobj_list)
+        #
+        # Calculate the net force X, Y, and Z , 10.2.0(d) now per part constant variable
+        #
+        force_calc_string = "ENS_Force_Net_press_X = StatMoment"
+        calc_string = "(plist," +  'ENS_Force_press_X , 0, Compute_Per_part )'
+        temp_string = force_calc_string + calc_string
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return []
+        #
+        force_calc_string = "ENS_Force_Net_press_Y = StatMoment"
+        calc_string = "(plist," +  'ENS_Force_press_Y , 0, Compute_Per_part )'
+        temp_string = force_calc_string + calc_string
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return []
+        #
+        force_calc_string = "ENS_Force_Net_press_Z = StatMoment"
+        calc_string = "(plist," +  'ENS_Force_press_Z , 0, Compute_Per_part )'
+        temp_string = force_calc_string + calc_string
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return []
+        #
+        # Calculate the Total force X, Y, and Z , 10.2.0(d) now case constant variable
+        #  Totals are a case constants. We don't do anything with these vars
+        #   they are calc'd to give the user the totals.
+        #
+        force_calc_string = "ENS_Force_Total_Net_press_X = StatMoment"
+        calc_string = "(plist," +  'ENS_Force_press_X , 0, Compute_Per_case )'
+        temp_string = force_calc_string + calc_string
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return []
+        #
+        force_calc_string = "ENS_Force_Total_Net_press_Y = StatMoment"
+        calc_string = "(plist," +  'ENS_Force_press_Y , 0, Compute_Per_case )'
+        temp_string = force_calc_string + calc_string
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return []
+        #
+        force_calc_string = "ENS_Force_Total_Net_press_Z = StatMoment"
+        calc_string = "(plist," +  'ENS_Force_press_Z , 0, Compute_Per_case )'
+        temp_string = force_calc_string + calc_string
+        if 0 != self._calc_var(pobj_list,temp_string):
+            return []
+        #
+        # get a list with a per part force, one for each part, new 10.1.6(b)
+        #
+        Fx = self.get_const_val("ENS_Force_Net_press_X",pobj_list)
+        Fy = self.get_const_val("ENS_Force_Net_press_Y",pobj_list)
+        Fz = self.get_const_val ("ENS_Force_Net_press_Z",pobj_list)
+        #
+        #
+        # Fr, Ft, Fa
+        #
+        if frame_index > 0 and frame_index < len(self.ensight.objs.core.FRAMES): # user picked non-zero frame index
+            #
+            self.ensight.utils.parts.select_parts(pobj_list)
+            #
+            #  per part constant as of 10.2.0(d)
+            #
+            force_calc_string = "ENS_Force_Net_press_R = StatMoment"
+            calc_string = "(plist," + 'ENS_Force_press_R, 0, Compute_Per_part )'
+            temp_string = force_calc_string + calc_string
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return []
+            #
+            force_calc_string = "ENS_Force_Net_press_T = StatMoment"
+            calc_string = "(plist," + 'ENS_Force_press_T, 0, Compute_Per_part )'
+            temp_string = force_calc_string + calc_string
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return []
+            #
+            force_calc_string = "ENS_Force_Net_press_A = StatMoment"
+            calc_string = "(plist," + 'ENS_Force_press_A, 0, Compute_Per_part )'
+            temp_string = force_calc_string + calc_string
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return []
+            #
+            #  Totals are a case constants. We don't do anything with these vars
+            #   they are calc'd to give the user the totals.
+            #
+            force_calc_string = "ENS_Force_Total_Net_press_R = StatMoment"
+            calc_string = "(plist," + 'ENS_Force_press_R, 0, Compute_Per_case )'
+            temp_string = force_calc_string + calc_string
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return []
+            #
+            force_calc_string = "ENS_Force_Total_Net_press_T = StatMoment"
+            calc_string = "(plist," + 'ENS_Force_press_T, 0, Compute_Per_case )'
+            temp_string = force_calc_string + calc_string
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return []
+            #
+            force_calc_string = "ENS_Force_Total_Net_press_A = StatMoment"
+            calc_string = "(plist," + 'ENS_Force_press_A, 0, Compute_Per_case )'
+            temp_string = force_calc_string + calc_string
+            if 0 != self._calc_var(pobj_list,temp_string):
+                return []
+            #
+            #   get a list with a per part force, one for each part, new 10.1.6(b)
+            #
+            Fr = self.get_const_val("ENS_Force_Net_press_R",pobj_list)
+            Ft = self.get_const_val("ENS_Force_Net_press_T",pobj_list)
+            Fa = self.get_const_val("ENS_Force_Net_press_A",pobj_list)
+            #
+            if Fr != None and Ft != None and Fa != None and Fx != None and Fy != None and Fz != None: 
+                ret_val = []
+                for ii in range(len(pobj_list)):
+                    ret_val.append([Fx[ii],Fy[ii],Fz[ii],Fr[ii],Ft[ii],Fa[ii]])
+                return ret_val
+            else:
+                err_string = "Error getting XYZ and/or Cylindrical RTZ Pressure Net Force per part constant values"
+                self.ensight.int_message(err_string,1)
+                return []
+        else: # either only one Frame or Frame 0 has been chosen so no cylindrical calc
+            if Fx != None and Fy != None and Fz != None: 
+                ret_val = []
+                for ii in range(len(pobj_list)):
+                    ret_val.append([Fx[ii],Fy[ii],Fz[ii],0.0,0.0,0.0])
+                return ret_val
+            else:
+                err_string = "Error getting Fx, Fy, and/or Fz Pressure Net force per part constant values"
+                self.ensight.int_message(err_string,1)
+                return []
+
+    #
+    #  Writes out the lists part by part
+    #
+    def write_out_force_data(self, filename, original_part_selection_list, params, press_force_list, shear_force_list, press_coeff_list, shear_coeff_list, \
+        press_LDS_force_list, shear_LDS_force_list, press_LDS_coeff_list, shear_LDS_coeff_list):
+    
+        if len(press_force_list) > 0:  # FIX ME what if we have no pressure force list but do have shear force list???
+            try:
+                fp = open(filename,"w")
+            except:
+                self.ensight.int_message("Error Failed to open output csv filename for writing '" + filename +"'",1)
+                return False
+    
+            if 1: 
+                temp_list = [0.,0.,0.]
+                #
+                #  get the input data filename from the server and write the filename for the current case
+                #                    
+                c = self.ensight.objs.core.CURRENTCASE[0]    # for c in ensight.objs.core.CASES.find(True, attr=ensight.objs.enums.ACTIVE):
+                fp.write("'"+os.path.join(c.SERVERDIR, c.SERVERINFO.get('file',''))+"'\n")
+                #
+                #  Write the gui input values to the .csv output file as  a second
+                #   line in the header
+                #
+                fp.write("Pressure variable name ," + params['press_varname'] + "\n")
+                if len(self.ensight.objs.core.FRAMES) > 0:
+                    if 'frame_index' in params:
+                        fp.write("Cylindrical reference frame coordinate system frame, " + str(params['frame_index'])+ "\n")
+                if ( 'shear_varname' in params) and ( params['shear_varname'] != "None") and ( params['shear_vartype'] != "None"):
+                    fp.write("Shear variable name, " + params['shear_varname'] + ", " + "\n")
+                    fp.write("Shear variable type, " + params['shear_vartype'] + "\n" )
+                if params['Area_ref'] > 0.0:
+                    fp.write("Reference Area, %.5f \n" % params['Area_ref'] )
+                    fp.write("Reference Density, %.5f \n" % params['Dens_ref'] )
+                    fp.write("Reference Velocity xyz, %.5f," % params['Vx_ref']  )
+                    fp.write("%.5f, " % params['Vy_ref'])
+                    fp.write("%.5f  \n" % params['Vz_ref'] )
+                    if (params['up_vector'] != "None"):
+                        fp.write('Up vector,' + params['up_vector'] + '\n')
+                fp.write("\n")
+                        
+                fp.write("Part ID,   Part Name , Pressure Force X , Pressure Force Y , Pressure Force Z , Total Pressure Force ")
+                if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
+                    fp.write(", Pressure Force Radial , Pressure Force Theta , Pressure Force Axial, Total Cyl Pressure Force ")
+                if len(shear_force_list):
+                    fp.write(", Shear Force X , Shear Force Y , Shear Force Z , Total Shear Force ")
+                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
+                        fp.write(", Shear Force Radial , Shear Force Theta , Shear Force Axial , Total Cyl Shear Force ")
+                    fp.write(", Press + Shear Force X , Press + Shear Force Y , Press + Shear Force Z , Total Press + Shear Force ")
+                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
+                        fp.write(", Press + Shear Force Radial , Press + Shear Force Theta , Press + Shear Force Axial , Total Press + Shear Force ")
+                if len(press_coeff_list):
+                    fp.write(", Coeff Press X , Coeff Press Y , Coeff Press Z , Total Coeff Press ")
+                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
+                        fp.write(", Coeff Press Radial , Coeff Press Theta , Coeff Press Axial , Total Coeff Press ")
+                if len(shear_coeff_list):
+                    fp.write(", Coeff Shear X , Coeff Shear Y , Coeff Shear Z , Total Coeff Shear ,")
+                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
+                        fp.write("Coeff Shear Radial , Coeff Shear Theta , Coeff Shear Axial , Total Coeff Shear ,")
+                    fp.write("Coeff Press + Shear X , Coeff Press + Shear Y , Coeff Press + Shear Z , Total Coeff Press + Shear")
+                    if len(self.ensight.objs.core.FRAMES) > 0 and ( 'frame_index' in params) and ( params['frame_index'] > 0):
+                        fp.write(", Coeff Press + Shear Radial , Coeff Press + Shear Theta , Coeff Press + Shear Axial , Total Coeff Press + Shear")
+                if len(press_LDS_force_list):
+                    fp.write(", Lift Force , Drag Force , Side Force , Total Pressure Force ")
+                if len(shear_LDS_force_list):
+                    fp.write(", Shear Force L , Shear Force D , Shear Force Side , Total Shear Force LDS ")
+                    fp.write(", Press + Shear Force L , Press + Shear Force D , Press + Shear Force Side , Total Press + Shear Force LDS ")
+                if len(press_LDS_coeff_list):
+                    fp.write(", Lift Coeff Press  , Drag Coeff Press , Side Coeff Press , Total Coeff Press ")
+                if len(shear_LDS_coeff_list):
+                    fp.write(", Lift Coeff Shear  , Drag Coeff Shear , Side Coeff Shear , Coeff Shear LDS Total,")
+                    fp.write("Coeff Press + Shear L , Coeff Press + Shear D , Coeff Press + Shear Side , Coeff Press + Shear LDS Total")
+                fp.write("\n")
+                #
+                #  Loop through and write out the vals
+                #
+                for ii in range(len(press_force_list)):
+                    fp.write(str(original_part_selection_list[ii].PARTNUMBER) + " , " + original_part_selection_list[ii].DESCRIPTION + " , ")
+                    #
+                    # pressure force components then magnitude
+                    #
+                    for jj in range(3):
+                        fp.write(str(press_force_list[ii][jj]))
+                        fp.write(" , ")
+                    fp.write(str( vec_mag(press_force_list[ii][:3]) )) # magnitude of Fx, Fy, Fz
+                    if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
+                        fp.write(" , ")
+                        for jj in range(3):
+                            fp.write(str(press_force_list[ii][jj+3]))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(press_force_list[ii][3:]) )) # magnitude of Cyl Fr, Ft, Fa
+                     #
+                    # shear force components then magnitude
+                    #
+                    if len(shear_force_list) > 0:
+                        fp.write(" , ")
+                        for jj in range(3):
+                            fp.write(str(shear_force_list[ii][jj]))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(shear_force_list[ii][:3]) ))
+                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
+                            fp.write(" , ")
+                            for jj in range(3):
+                                fp.write(str(shear_force_list[ii][jj+3]))
+                                fp.write(" , ")
+                            fp.write(str( vec_mag(shear_force_list[ii][3:]) ))
+                        fp.write(" , ")
+                        # sum of pressure and shear forces components then magnitude
+                        for jj in range(3):
+                            temp_list[jj] = press_force_list[ii][jj] + shear_force_list[ii][jj]
+                            fp.write(str( temp_list[jj] ))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(temp_list[:3]) ))
+                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
+                            fp.write(" , ")
+                            for jj in range(3):
+                                temp_list[jj] = press_force_list[ii][jj+3] + shear_force_list[ii][jj+3]
+                                fp.write(str( temp_list[jj] ))
+                                fp.write(" , ")
+                            fp.write(str( vec_mag(temp_list[:3]) ))
+                            
+                    #
+                    # Coefficient of pressure force components then magnitude
+                    #
+                    if len(press_coeff_list) > 0:
+                        fp.write(" , ")
+                        for jj in range(3):
+                            fp.write(str(press_coeff_list[ii][jj]))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(press_coeff_list[ii][:3]) ))
+                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
+                            fp.write(" , ")
+                            for jj in range(3):
+                                fp.write(str(press_coeff_list[ii][jj+3]))
+                                fp.write(" , ")
+                            fp.write(str( vec_mag(press_coeff_list[ii][3:]) )) 
+                    #
+                    # Coefficient shear force components then magnitude
+                    #
+                    if len(shear_coeff_list) > 0:
+                        fp.write(" , ")
+                        for jj in range(3):
+                            fp.write(str(shear_coeff_list[ii][jj]))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(shear_coeff_list[ii][:3]) ))
+                        fp.write(" , ")
+                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
+                            for jj in range(3):
+                                fp.write(str(shear_coeff_list[ii][jj+3]))
+                                fp.write(" , ")
+                            fp.write(str( vec_mag(shear_coeff_list[ii][3:]) ))
+                            fp.write(" , ")
+                        # sum of pressure and shear Coefficient components then magnitude
+                        for jj in range(3):
+                            temp_list[jj] = press_coeff_list[ii][jj] + shear_coeff_list[ii][jj]
+                            fp.write(str( temp_list[jj] ))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(temp_list) ))
+                        if len(self.ensight.objs.core.FRAMES) > 0 and ('frame_index' in params) and (params['frame_index'] > 0):
+                            fp.write(" , ")
+                            for jj in range(3):
+                                temp_list[jj] = press_coeff_list[ii][jj+3] + shear_coeff_list[ii][jj+3]
+                                fp.write(str( temp_list[jj] ))
+                                fp.write(" , ")
+                            fp.write(str( vec_mag(temp_list) ))
+                        fp.write(" , ")
+                    #
+                    # Lift, Drag and Side Force
+                    # No cylindrical stuff here
+                    # LDS pressure force components then magnitude
+                    #
+                    if len(press_LDS_force_list) > 0:
+                        for jj in range(3):
+                            fp.write(str(press_LDS_force_list[ii][jj]))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(press_LDS_force_list[ii][:3]) ))
+                        fp.write(" , ")
+                    # LDS shear force components then magnitude
+                    if len(shear_LDS_force_list) > 0:
+                        for jj in range(3):
+                            fp.write(str(shear_LDS_force_list[ii][jj]))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(shear_LDS_force_list[ii][:3]) ))
+                        fp.write(" , ")
+                        # LDS sum of pressure and shear forces components then magnitude
+                        for jj in range(3):
+                            temp_list[jj] = press_LDS_force_list[ii][jj] + shear_LDS_force_list[ii][jj]
+                            fp.write(str( temp_list[jj] ))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(temp_list) ))
+                        fp.write(" , ")
+                    # LDS Coefficient of pressure force components then magnitude
+                    if len(press_LDS_coeff_list) > 0:
+                        for jj in range(3):
+                            fp.write(str(press_LDS_coeff_list[ii][jj]))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(press_LDS_coeff_list[ii][:3]) ))
+                        fp.write(" , ")
+                    # LDS Coefficient shear force components then magnitude
+                    if len(shear_LDS_coeff_list) > 0:
+                        for jj in range(3):
+                            fp.write(str(shear_LDS_coeff_list[ii][jj]))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(shear_LDS_coeff_list[ii][:3] ) ))
+                        fp.write(" , ")
+                        # LDS sum of pressure and shear Coefficient components then magnitude
+                        for jj in range(3):
+                            temp_list[jj] = press_LDS_coeff_list[ii][jj] + shear_LDS_coeff_list[ii][jj]
+                            fp.write(str( temp_list[jj] ))
+                            fp.write(" , ")
+                        fp.write(str( vec_mag(temp_list) ))
+                    fp.write("\n")
+                #  FIX ME keep track of and write out totals here when loop is done on last line?
+                fp.close()
+                return True
+            else:
+                self.ensight.int_message("Error opening filename: '{}'".format(filename),1)
+                return False
+        else:
+            self.ensight.int_message("Error no pressure force list to write out",1)
+            return False

--- a/tests/example_tests/test_force_tool.py
+++ b/tests/example_tests/test_force_tool.py
@@ -42,7 +42,7 @@ def create_frame(ensight):
     ensight.frame.assign(0)
 
 
-def test_async_events(tmpdir, pytestconfig: pytest.Config):
+def test_force_tool(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     use_local = pytestconfig.getoption("use_local_launcher")
     if use_local:

--- a/tests/example_tests/test_force_tool.py
+++ b/tests/example_tests/test_force_tool.py
@@ -50,8 +50,9 @@ def test_force_tool(tmpdir, pytestconfig: pytest.Config):
     else:
         launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
-    session.download_pyansys_example("RC_Plane", "pyensight", folder=True)
-    session.load_data("RC_Plane/extra300_RC_Plane_cpp.case")
+    path = session.download_pyansys_example("RC_Plane", "pyensight", folder=True)
+    print(path)
+    session.load_data(os.path.join(path, "extra300_RC_Plane_cpp.case"))
     create_frame(session.ensight)
     body_parts = [
         "canopy",

--- a/tests/unit_tests/test_force_tool.py
+++ b/tests/unit_tests/test_force_tool.py
@@ -1,0 +1,83 @@
+import math
+import os
+from ansys.pyensight.core.dockerlauncher import DockerLauncher
+from ansys.pyensight.core.locallauncher import LocalLauncher
+import pytest
+
+def create_frame(ensight):
+    ensight.frame.create()
+    ensight.frame.select_begin(1)
+    ensight.frame.visible("OFF")
+    ensight.frame.type("rectangular")
+    ensight.frame.orientation_x(1,0,0)
+    ensight.frame.orientation_y(0,1,0)
+    ensight.frame.orientation_z(0,0,1)
+    ensight.frame.len_x(6.66666651)
+    ensight.frame.len_y(6.66666651)
+    ensight.frame.len_z(6.66666651)
+    ensight.frame.number_of_labels_x(3)
+    ensight.frame.number_of_labels_y(3)
+    ensight.frame.number_of_labels_z(3)
+    ensight.frame.line_width(1)
+    ensight.frame.rgb(1,1,1)
+    ensight.frame.x_labels("OFF")
+    ensight.frame.y_labels("OFF")
+    ensight.frame.z_labels("OFF")
+    ensight.frame.symmetry_type("none")
+    ensight.frame.symmetry_angle(30)
+    ensight.frame.symmetry_rinstances(1)
+    ensight.frame.symmetry_mirror_z("OFF")
+    ensight.frame.symmetry_mirror_y("OFF")
+    ensight.frame.symmetry_mirror_x("OFF")
+    ensight.frame.symmetry_mirror_xy("OFF")
+    ensight.frame.symmetry_mirror_yz("OFF")
+    ensight.frame.symmetry_mirror_xz("OFF")
+    ensight.frame.symmetry_mirror_xyz("OFF")
+    ensight.frame.symmetry_use_file("OFF")
+    ensight.frame.symmetry_tinstances(1)
+    ensight.frame.symmetry_delta(0,0,0)
+    ensight.frame.symmetry_axis("z")
+    ensight.frame.assign(0)
+
+
+def test_async_events(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
+        launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
+    session.download_pyansys_example("RC_Plane", "pyensight", folder=True)
+    session.load_data("RC_Plane/extra300_RC_Plane_cpp.case")
+    create_frame(session.ensight)
+    body_parts = ["canopy", "fuselage", "horizontal_stabilizer", "nose", "vertical_stabilizer", "wing_lower_surface", "wing_te", "wing_tip", "wing_upper_surface"]
+    vref = session.ensight.utils.variables.get_const_val("Vinf")
+    dref = session.ensight.utils.variables.get_const_val("Rho")
+    aoa = session.ensight.utils.variables.get_const_val("AoA")
+    vxref = vref * math.cos(aoa * math.pi / 180)
+    vyref = vref * math.sin(aoa * math.pi / 180)
+    vzref = 0
+    area_ref = None
+    if session.ensight.utils.variables._calc_var(["wing_upper_surface"], "area_ref = Area(plist)"):
+        area_ref = session.ensight.utils.variables.get_const_val("area_ref")
+
+    if not area_ref:
+        raise RuntimeError("The reference area could not be calculated")
+    session.ensight.utils.variables.compute_forces(
+        pobj_list=body_parts.copy(), 
+        press_var_obj="staticPressure", 
+        shear_var_obj="wallShearStress", 
+        shear_var_type=session.ensight.utils.variables.SHEAR_VAR_TYPE_STRESS, 
+        export_filename="test.csv",
+        area_ref=area_ref,
+        density_ref=dref,
+        velocity_x_ref=vxref,
+        velocity_y_ref=vyref,
+        velocity_z_ref=vzref,
+        up_vector=session.ensight.utils.variables.UP_VECTOR_PLUS_Y,
+        frame_index=1
+    )
+    assert os.path.exists("test.csv")
+
+    

--- a/tests/unit_tests/test_force_tool.py
+++ b/tests/unit_tests/test_force_tool.py
@@ -1,17 +1,19 @@
 import math
 import os
+
 from ansys.pyensight.core.dockerlauncher import DockerLauncher
 from ansys.pyensight.core.locallauncher import LocalLauncher
 import pytest
+
 
 def create_frame(ensight):
     ensight.frame.create()
     ensight.frame.select_begin(1)
     ensight.frame.visible("OFF")
     ensight.frame.type("rectangular")
-    ensight.frame.orientation_x(1,0,0)
-    ensight.frame.orientation_y(0,1,0)
-    ensight.frame.orientation_z(0,0,1)
+    ensight.frame.orientation_x(1, 0, 0)
+    ensight.frame.orientation_y(0, 1, 0)
+    ensight.frame.orientation_z(0, 0, 1)
     ensight.frame.len_x(6.66666651)
     ensight.frame.len_y(6.66666651)
     ensight.frame.len_z(6.66666651)
@@ -19,7 +21,7 @@ def create_frame(ensight):
     ensight.frame.number_of_labels_y(3)
     ensight.frame.number_of_labels_z(3)
     ensight.frame.line_width(1)
-    ensight.frame.rgb(1,1,1)
+    ensight.frame.rgb(1, 1, 1)
     ensight.frame.x_labels("OFF")
     ensight.frame.y_labels("OFF")
     ensight.frame.z_labels("OFF")
@@ -35,7 +37,7 @@ def create_frame(ensight):
     ensight.frame.symmetry_mirror_xyz("OFF")
     ensight.frame.symmetry_use_file("OFF")
     ensight.frame.symmetry_tinstances(1)
-    ensight.frame.symmetry_delta(0,0,0)
+    ensight.frame.symmetry_delta(0, 0, 0)
     ensight.frame.symmetry_axis("z")
     ensight.frame.assign(0)
 
@@ -51,7 +53,17 @@ def test_async_events(tmpdir, pytestconfig: pytest.Config):
     session.download_pyansys_example("RC_Plane", "pyensight", folder=True)
     session.load_data("RC_Plane/extra300_RC_Plane_cpp.case")
     create_frame(session.ensight)
-    body_parts = ["canopy", "fuselage", "horizontal_stabilizer", "nose", "vertical_stabilizer", "wing_lower_surface", "wing_te", "wing_tip", "wing_upper_surface"]
+    body_parts = [
+        "canopy",
+        "fuselage",
+        "horizontal_stabilizer",
+        "nose",
+        "vertical_stabilizer",
+        "wing_lower_surface",
+        "wing_te",
+        "wing_tip",
+        "wing_upper_surface",
+    ]
     vref = session.ensight.utils.variables.get_const_val("Vinf")
     dref = session.ensight.utils.variables.get_const_val("Rho")
     aoa = session.ensight.utils.variables.get_const_val("AoA")
@@ -65,10 +77,10 @@ def test_async_events(tmpdir, pytestconfig: pytest.Config):
     if not area_ref:
         raise RuntimeError("The reference area could not be calculated")
     session.ensight.utils.variables.compute_forces(
-        pobj_list=body_parts.copy(), 
-        press_var_obj="staticPressure", 
-        shear_var_obj="wallShearStress", 
-        shear_var_type=session.ensight.utils.variables.SHEAR_VAR_TYPE_STRESS, 
+        pobj_list=body_parts.copy(),
+        press_var_obj="staticPressure",
+        shear_var_obj="wallShearStress",
+        shear_var_type=session.ensight.utils.variables.SHEAR_VAR_TYPE_STRESS,
         export_filename="test.csv",
         area_ref=area_ref,
         density_ref=dref,
@@ -76,8 +88,6 @@ def test_async_events(tmpdir, pytestconfig: pytest.Config):
         velocity_y_ref=vyref,
         velocity_z_ref=vzref,
         up_vector=session.ensight.utils.variables.UP_VECTOR_PLUS_Y,
-        frame_index=1
+        frame_index=1,
     )
     assert os.path.exists("test.csv")
-
-    


### PR DESCRIPTION
This is the first step of moving the net_force tool from EnSight to PyEnSight.

All the functions needed for computing the forces and exporting the forces to a csv file have been converted to PyEnSight functions. 

As part of the process:

1. Some ens_utils functions needed porting, so you will find them among the new functions
2. I choose to make some functions "private", mostly the ones that are actually doing the force computation in EnSight. This is because I then created a one, centralized function "compute_forces" which is the one customers should use. The net_force tool in EnSight will call the "private" functions to do the computation
3. There are, anyway, some functions which I kept "public", like get_const_val and similar. They have a purpose for customers so it was nice to leave them public

You will find some area where I had to do odd tricks to make mypy happy. Mostly this has been happening with the output of functions like "get_const_val", which can either output a float or a List of floats. mypy just doesn't know what will get so, depending on the moment it got called, where I knew the kind of output, I just made mypy understand what was the right return type.
There are other examples though, and I believe I have added comments in the code to highlight it. So don't panic if some code seems weird or "useless"


The second step after this will be to heavily simplify the extension in EnSight so that it calls this new code instead of doing the computations by itself



I have also created a unit test exercising it, using the RC Plane which is downloaded from the example-data repo. Since in this case we are downloading a folder, and not just a file, I have modified the download_pyansys_example interface so that you can tell it to download the full folder supplied, and change the script executed remotely accordingly