### PR TITLE
Fix/session str badhostname

### DIFF
--- a/src/ansys/pyensight/core/session.py
+++ b/src/ansys/pyensight/core/session.py
@@ -113,6 +113,14 @@ class Session:
     >>> from ansys.pyensight.core import LocalLauncher
     >>> session = LocalLauncher().start()
 
+    >>> # Launch an instance of EnSight, then create a second conection to the instance
+    >>> from ansys.pyensight.core import LocalLauncher, Session
+    >>> launched_session = LocalLauncher().start()
+    >>> # Get a string that can be used to create a second connection
+    >>> session_string = str(launched_session)
+    >>> # Create a second connection to the same EnSight instance
+    >>> connected_session = eval(session_string)
+
     """
 
     def __init__(
@@ -257,7 +265,7 @@ class Session:
             session_dir = self.launcher.session_directory
         s = f"Session(host='{self.hostname}', secret_key='{self.secret_key}', "
         s += f"sos={self.sos}, rest_api={self.rest_api}, "
-        s += f"html_hostname={self.html_hostname}, html_port={self.html_port}, "
+        s += f"html_hostname='{self.html_hostname}', html_port={self.html_port}, "
         s += f"grpc_port={self._grpc_port}, "
         s += f"ws_port={self.ws_port}, session_directory=r'{session_dir}')"
         return s

--- a/src/ansys/pyensight/core/session.py
+++ b/src/ansys/pyensight/core/session.py
@@ -113,7 +113,7 @@ class Session:
     >>> from ansys.pyensight.core import LocalLauncher
     >>> session = LocalLauncher().start()
 
-    >>> # Launch an instance of EnSight, then create a second conection to the instance
+    >>> # Launch an instance of EnSight, then create a second connection to the instance
     >>> from ansys.pyensight.core import LocalLauncher, Session
     >>> launched_session = LocalLauncher().start()
     >>> # Get a string that can be used to create a second connection

--- a/tests/unit_tests/test_session.py
+++ b/tests/unit_tests/test_session.py
@@ -52,6 +52,13 @@ def test_show(mocked_session, mocker):
     assert "No websocketserver has been associated with this Session" in str(exec_info)
 
 
+def test_clone(mocked_session):
+    session = mocked_session
+    cmd = str(session)
+    second_connection = eval(cmd)
+    assert session.secret_key() == second_connection.secret_key()
+
+
 def test_exec(mocked_session):
     def function(*args, **kwargs):
         return True

--- a/tests/unit_tests/test_session.py
+++ b/tests/unit_tests/test_session.py
@@ -4,7 +4,7 @@ from unittest import mock
 import webbrowser
 
 import ansys.pyensight.core
-from ansys.pyensight.core.launcher import Launcher
+from ansys.pyensight.core.launcher import Launcher, Session
 import ansys.pyensight.core.renderable
 import pytest
 

--- a/tests/unit_tests/test_session.py
+++ b/tests/unit_tests/test_session.py
@@ -4,8 +4,9 @@ from unittest import mock
 import webbrowser
 
 import ansys.pyensight.core
-from ansys.pyensight.core.launcher import Launcher, Session  # noqa: F401
+from ansys.pyensight.core.launcher import Launcher
 import ansys.pyensight.core.renderable
+from ansys.pyensight.core.session import Session  # noqa: F401
 import pytest
 
 
@@ -56,7 +57,7 @@ def test_clone(mocked_session):
     session = mocked_session
     cmd = str(session)
     second_connection = eval(cmd)
-    assert session.secret_key() == second_connection.secret_key()
+    assert session.secret_key == second_connection.secret_key
 
 
 def test_exec(mocked_session):

--- a/tests/unit_tests/test_session.py
+++ b/tests/unit_tests/test_session.py
@@ -4,7 +4,7 @@ from unittest import mock
 import webbrowser
 
 import ansys.pyensight.core
-from ansys.pyensight.core.launcher import Launcher, Session
+from ansys.pyensight.core.launcher import Launcher, Session # noqa: F401
 import ansys.pyensight.core.renderable
 import pytest
 

--- a/tests/unit_tests/test_session.py
+++ b/tests/unit_tests/test_session.py
@@ -4,7 +4,7 @@ from unittest import mock
 import webbrowser
 
 import ansys.pyensight.core
-from ansys.pyensight.core.launcher import Launcher, Session # noqa: F401
+from ansys.pyensight.core.launcher import Launcher, Session  # noqa: F401
 import ansys.pyensight.core.renderable
 import pytest
 


### PR DESCRIPTION
There was a bug in the str(Session) call.  html_hostname keyword output generated invalid Python code.