### PR TITLE
use old vnc workflow for 241 in order to support EnSight 241 on AnsysLab with recent wheels

### DIFF
--- a/src/ansys/pyensight/core/renderable.py
+++ b/src/ansys/pyensight/core/renderable.py
@@ -563,7 +563,8 @@ class RenderableVNC(Renderable):
         """
         optional_query = self._get_query_parameters_str()
         version = _get_ansysnexus_version(self._session._cei_suffix)
-        if int(self._session._cei_suffix) < 241:
+        if int(self._session._cei_suffix) < 242:
+            version = ""
             self._update_2023R2_or_less()
         else:
             html = (


### PR DESCRIPTION
The new workflow for the VNC renderable works locally with EnSight 241 or later.
However, on AnsysLab (or docker in general) EnSight 241 cannot handle the new workflow, while 242 can. To work with 241, one should use at most a pyensight of version 0.6.2, but they would like to claim backward compat support even with the most recent versions of the wheel

So the fix is simple, that is to use the old VNC workflow in case EnSight is equal or less than 241 instead of just 232

Before merging this PR, I will wait for Jerome to confirm that this new wheel (which I generated for him) works with both 241 and 242