### PR TITLE
Handle backslash in partnames

### DIFF
--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -337,6 +337,7 @@ class OmniverseWrapper:
         name = name.replace("<", "_").replace(">", "_")
         name = name.replace("/", "_").replace("=", "_")
         name = name.replace(",", "_").replace(" ", "_")
+        name = name.replace("\\", "_")
         if id_name is not None:
             name = name + "_" + str(id_name)
         if name in self._cleaned_names.values():


### PR DESCRIPTION
EnSight partnames can contain backslashes.  Replace them.