### PR TITLE
Mostieri/prepare for 2024 r2 metapackage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-pyensight-core"
-version = "0.8.0.dev0"
+version = "0.9.0.dev0"
 description = "A python wrapper for Ansys EnSight"
 readme = "README.rst"
 requires-python = ">=3.9,<4"
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
     "importlib-metadata>=4.0; python_version<='3.8'",
-    "ansys-api-pyensight==0.3.10",
+    "ansys-api-pyensight==0.4.0",
     "requests>=2.28.2",
     "docker>=6.1.0",
     "urllib3<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-pyensight-core"
-version = "0.9.0.dev0"
+version = "0.8.0.dev0"
 description = "A python wrapper for Ansys EnSight"
 readme = "README.rst"
 requires-python = ">=3.9,<4"


### PR DESCRIPTION
This is just a PR to align the final patch release to the final "2024R2" API release.
In this way, the metapackage will point to v0.8.0 for PyEnSight and v0.4.0 for the API.

Next step, after the milestone release, will be to change main to point to v0.9.0dev0 and create the release/0.8 branch