### PR TITLE
Mostieri/live dvs

### DIFF
--- a/src/ansys/pyensight/core/session.py
+++ b/src/ansys/pyensight/core/session.py
@@ -1778,3 +1778,38 @@ class Session:
                 message = f"A newer version of EnSight is required to use this API:{base_msg}"
             raise InvalidEnSightVersion(message)
         return valid
+
+    def find_remote_unused_ports(
+        self,
+        count: int,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        avoid: Optional[list[int]] = None,
+    ) -> Optional[List[int]]:
+        """
+        Find "count" unused ports on the host system.  A port is considered
+        unused if it does not respond to a "connect" attempt.  Walk the ports
+        from 'start' to 'end' looking for unused ports and avoiding any ports
+        in the 'avoid' list.  Stop once the desired number of ports have been
+        found.  If an insufficient number of ports were found, return None.
+        An admin user check is used to skip [1-1023].
+
+        Parameters
+        ----------
+        count: int
+            number of unused ports to find
+        start: int
+            the first port to check or None (random start)
+        end: int
+            the last port to check or None (full range check)
+        avoid: list
+            an optional list of ports not to check
+
+        Returns
+        -------
+            the detected ports or None on failure
+        """
+        cmd = "from cei import find_unused_ports\n"
+        cmd += f"ports = find_unused_ports({count}, start={start}, end={end}, avoid={avoid})"
+        self.cmd(cmd, do_eval=False)
+        return self.cmd("ports")

--- a/src/ansys/pyensight/core/utils/readers.py
+++ b/src/ansys/pyensight/core/utils/readers.py
@@ -35,11 +35,11 @@ class DVS:
 
     def launch_live_dvs(
         self,
-        port: int = 0,
+        port: int,
         secret_key: Optional[str] = None,
-        threaded: Optional[bool] = False,
         monitor_new_timesteps: str = MONITOR_NEW_TIMESTEPS_STAY_AT_CURRENT,
-    ) -> Optional[Thread]:
+        start_thread: bool = True,
+    ) -> Thread:
         """To provide an interface to launch an in-situ EnSight DVS session.
 
         Parameters
@@ -48,18 +48,21 @@ class DVS:
             the port number where the first DVS server will be started. In case of a
             SOS EnSight session, on the following server the DVS servers will be started on the
             next port, e.g. if the first server starts at port 50055, the second will start
-            at port 50056 and so on. Defaults to 0, which is the random port
+            at port 50056 and so on
         secret_key: str
             an optional secret key to pass in case the DVS clients have been started with a secret key
             for the underlying gRPC connections. An empty string can be provided if needed
-        threaded: bool
-            if True, the DVS loading will be started as a thread, and the thread itself we'll be returned.
         monitor_new_timesteps: str
             set the way EnSight will monitor for new timesteps. Defaults to MONITOR_NEW_TIMESTEPS_STAY_AT_CURRENT.
             The allowed values are MONITOR_NEW_TIMESTEPS_STAY_AT_CURRENT
             and MONITOR_NEW_TIMESTEPS_JUMP_TO_END
+        start_thread: bool
+            True if the thread to be returned needs to be started already. Default is True
 
-
+        Returns
+        -------
+        Thread:
+            a python Thread which holds the dvs load
         """
 
         def load_dvs():
@@ -85,9 +88,7 @@ class DVS:
         cmd += f'ensight.solution_time.monitor_for_new_steps("{monitor_new_timesteps}")\n'
         cmd += 'ensight.data.replace("notexisting.dvs")\n'
         cmd += "ensight.objs.core.CURRENTCASE[0].client_command_callback(None)"
-        if threaded:
-            t = Thread(target=load_dvs)
+        t = Thread(target=load_dvs)
+        if start_thread:
             t.start()
-            return t
-        load_dvs()
-        return None
+        return t

--- a/src/ansys/pyensight/core/utils/readers.py
+++ b/src/ansys/pyensight/core/utils/readers.py
@@ -1,4 +1,4 @@
-from types import ModuleType
+from threading import Thread
 from typing import Optional, Union
 
 try:
@@ -11,7 +11,7 @@ class Readers:
     def __init__(self, interface: Union["ensight_api.ensight", "ensight"]):
         self._ensight = interface
         self._dvs = DVS(self._ensight)
-    
+
     @property
     def dvs(self):
         return self._dvs
@@ -20,20 +20,29 @@ class Readers:
 class DVS:
     def __init__(self, interface: Union["ensight_api.ensight", "ensight"]):
         self._ensight = interface
-        
-    def launch_live_dvs(self, port: int = 0, secret_key: Optional[str] = None):
+
+    def launch_live_dvs(
+        self, 
+        port: int = 0, 
+        secret_key: Optional[str] = None, 
+        threaded: Optional[bool] = False
+    ) -> Optional[Thread]:
         indent = "    "
         cmd = "def dvs_callback():\n"
         cmd += f'{indent}command_string = f"set_server_port={port}"\n'
-        if secret_key:
+        if secret_key is not None:
             secret_string = f'{indent}command_string += f"&set_secret_key='
             secret_string += "'" + secret_key + "'" + '"\n'
             cmd += secret_string
-        cmd += f"{indent}reply = ensight.objs.core.CURRENTCASE[0].client_command(command_string)"
-        cmd += f'{indent}return f"{port}" in str(reply)'
-        cmd += "ensight.objs.core.CURRENTCASE[0].client_command_callback(dvs_callback)"
-        cmd += 'ensight.solution_time.monitor_for_new_steps("stay_at_current")'
-        cmd += 'ensight.data.replace("notexisting.dvs")'
+        cmd += f"{indent}reply = ensight.objs.core.CURRENTCASE[0].client_command(command_string)\n"
+        cmd += f'{indent}return f"{port}" in str(reply)\n\n'
+        cmd += "ensight.objs.core.CURRENTCASE[0].client_command_callback(dvs_callback)\n"
+        cmd += 'ensight.solution_time.monitor_for_new_steps("stay_at_current")\n'
+        cmd += 'ensight.data.replace("notexisting.dvs")\n'
         cmd += "ensight.objs.core.CURRENTCASE[0].client_command_callback(None)"
-        self._ensight._session.cmd(cmd)
-
+        load_dvs = lambda: self._ensight._session.cmd(cmd, do_eval=False)
+        if threaded:
+            t = Thread(target = load_dvs)
+            t.start()
+            return t
+        load_dvs()

--- a/src/ansys/pyensight/core/utils/readers.py
+++ b/src/ansys/pyensight/core/utils/readers.py
@@ -1,0 +1,39 @@
+from types import ModuleType
+from typing import Optional, Union
+
+try:
+    import ensight
+except ImportError:
+    from ansys.api.pyensight import ensight_api
+
+
+class Readers:
+    def __init__(self, interface: Union["ensight_api.ensight", "ensight"]):
+        self._ensight = interface
+        self._dvs = DVS(self._ensight)
+    
+    @property
+    def dvs(self):
+        return self._dvs
+
+
+class DVS:
+    def __init__(self, interface: Union["ensight_api.ensight", "ensight"]):
+        self._ensight = interface
+        
+    def launch_live_dvs(self, port: int = 0, secret_key: Optional[str] = None):
+        indent = "    "
+        cmd = "def dvs_callback():\n"
+        cmd += f'{indent}command_string = f"set_server_port={port}"\n'
+        if secret_key:
+            secret_string = f'{indent}command_string += f"&set_secret_key='
+            secret_string += "'" + secret_key + "'" + '"\n'
+            cmd += secret_string
+        cmd += f"{indent}reply = ensight.objs.core.CURRENTCASE[0].client_command(command_string)"
+        cmd += f'{indent}return f"{port}" in str(reply)'
+        cmd += "ensight.objs.core.CURRENTCASE[0].client_command_callback(dvs_callback)"
+        cmd += 'ensight.solution_time.monitor_for_new_steps("stay_at_current")'
+        cmd += 'ensight.data.replace("notexisting.dvs")'
+        cmd += "ensight.objs.core.CURRENTCASE[0].client_command_callback(None)"
+        self._ensight._session.cmd(cmd)
+

--- a/src/ansys/pyensight/core/utils/readers.py
+++ b/src/ansys/pyensight/core/utils/readers.py
@@ -1,4 +1,4 @@
-"""Parts module.
+"""Readers module.
 
 This module contains utilities to do readers specific operations.
 """


### PR DESCRIPTION
An interface to set up an in-situ live DVS connection in EnSight is provided.
One can set the port and the secret key (which can be passed also as the empty string), and EnSight will start the DVS reader monitoring for new timesteps. By default it will stay at the current timestep but the value can be changed

In a first attempt I allowed to set the port to 0 by default, and tried to get back the port via callbacks. While that worked, apparently if you first launch the EnSight thread, get the random port allocated via the callbacks and then you launch the Fluent thread feeding the port that you get back, it doesn't work.
However, if you get the random port outside of DVS, you can still start first the EnSight thread and then the Fluent thread.

So, I exposed the find_unused_port cei function in the session class, to get the random ports from the remote session, and made the port a required input