### PR TITLE
use local RC plane if local ensight; retry download in case of docker

### DIFF
--- a/tests/example_tests/test_force_tool.py
+++ b/tests/example_tests/test_force_tool.py
@@ -1,5 +1,6 @@
 import math
 import os
+import time
 
 from ansys.pyensight.core.dockerlauncher import DockerLauncher
 from ansys.pyensight.core.locallauncher import LocalLauncher
@@ -50,7 +51,21 @@ def test_force_tool(tmpdir, pytestconfig: pytest.Config):
     else:
         launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
-    path = session.download_pyansys_example("RC_Plane", "pyensight", folder=True)
+    path = None
+    if use_local:
+        path = f"{session.cei_home}/ensight{session.cei_suffix}/data/RC_Plane/"
+    else:
+        count = 0
+        success = False
+        while(not success and count < 5):
+            try:
+                path = session.download_pyansys_example("RC_Plane", "pyensight", folder=True)
+                success = True
+            except:
+                time.sleep(5)
+                count += 1
+        if count == 5 and success is False:
+            raise RuntimeError("Download of RC Plane case not possible")
     session.load_data(os.path.join(path, "extra300_RC_Plane_cpp.case"))
     create_frame(session.ensight)
     body_parts = [

--- a/tests/example_tests/test_force_tool.py
+++ b/tests/example_tests/test_force_tool.py
@@ -57,11 +57,11 @@ def test_force_tool(tmpdir, pytestconfig: pytest.Config):
     else:
         count = 0
         success = False
-        while(not success and count < 5):
+        while not success and count < 5:
             try:
                 path = session.download_pyansys_example("RC_Plane", "pyensight", folder=True)
                 success = True
-            except:
+            except Exception:
                 time.sleep(5)
                 count += 1
         if count == 5 and success is False:


### PR DESCRIPTION
During ADO builds, and sometimes even on github builds, the download of the RC Plane case from the example data pyansys github repository might fail. On ADO this is troublesome since one has to rerun a full build just because of that

Since on ADO builds there's no need to download the data I have now changes the test to switch to the local path.
In case of the github builds instead, I have implemented a retry strategy