### PR TITLE
bump to api 0.4.1 to add typehints support for readers utils; bypass docker module issue; add docs for readers utils

### DIFF
--- a/doc/source/class_documentation.rst
+++ b/doc/source/class_documentation.rst
@@ -46,3 +46,4 @@ PyEnSight using the ``ansys.pyensight.core.Session.ensight`` interface.
    ansys.pyensight.core.utils.views.Views
    ansys.pyensight.core.utils.variables.Variables
    ansys.pyensight.core.utils.omniverse.Omniverse
+   ansys.pyensight.core.utils.readers.Readers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,15 @@ classifiers = [
 
 dependencies = [
     "importlib-metadata>=4.0; python_version<='3.8'",
-    "ansys-api-pyensight==0.4.0",
+    "ansys-api-pyensight==0.4.1",
     "requests>=2.28.2",
     "docker>=6.1.0",
     "urllib3<2",
     "numpy>=1.21.0,<2",
     "Pillow>=9.3.0",
     "pypng>=0.0.20",
-    "psutil>=5.9.2"
+    "psutil>=5.9.2",
+    "requests<2.32.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
So, the PR mainly addresses typehints and docs support for the readers utils (and so dvs, and so the live connection function).

There is an ongoing issue with the docker module broken because of a change in the requests module. The fix is to limit the requests version. I have no idea on what is the timing on the fix on the docker module, so for the moment I added a dep to limit the requests version