### PR TITLE
Force the requests version to avoid issues with docker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "importlib-metadata>=4.0; python_version<='3.8'",
     "ansys-api-pyensight==0.4.0",
-    "requests>=2.28.2",
+    "requests>=2.28.2,<2.32",
     "docker>=6.1.0",
     "urllib3<2",
     "numpy>=1.21.0,<2",
@@ -51,7 +51,7 @@ tests = [
     "dill>=0.3.5.1",
     "pytest-mock==3.10.0",
     "urllib3==1.26.10",
-    "requests>=2.28.2",
+    "requests>=2.28.2,<2.32",
     "docker>=6.1.0",
 ]
 doc = [
@@ -63,7 +63,7 @@ doc = [
     "sphinxcontrib-mermaid==0.9.2",
     "docker>=6.1.0",
     "matplotlib==3.7.2",
-    "requests>=2.28.2",
+    "requests>=2.28.2,<2.32",
     "sphinxcontrib.jquery==4.1",
     "coverage-badge==1.1.0",
     "sphinxcontrib-openapi==0.8.1",


### PR DESCRIPTION
The new version v2.32.X of requests, changed the behavior in which the send command works - and other libraries like docker-py (which were overriding the behavior of underlying functions in the requests library) started failing.

Force the version to be < 2.32 while the other libraries get updated