### PR TITLE
add temporary backdoor to allow ADR upgrade of jquery library

### DIFF
--- a/src/ansys/pyensight/core/renderable.py
+++ b/src/ansys/pyensight/core/renderable.py
@@ -382,10 +382,19 @@ class RenderableDeepPixel(Renderable):
             html = fp.read()
         # copy some files from Nexus
         cmd = "import shutil, enve, ceiversion, os.path\n"
-        for script in ["jquery-3.4.1.min.js", "geotiff.js", "geotiff_nexus.js", "bootstrap.min.js"]:
-            name = "os.path.join(enve.home(), f'nexus{ceiversion.nexus_suffix}', 'django', "
-            name += f"'website', 'static', 'website', 'scripts', '{script}')"
+        base_name = "os.path.join(enve.home(), f'nexus{ceiversion.nexus_suffix}', 'django', "
+        base_name += "'website', 'static', 'website', 'scripts', "
+        for script in ["geotiff.js", "geotiff_nexus.js", "bootstrap.min.js"]:
+            name = base_name + f"'{script}')"
             cmd += f'shutil.copy({name}, r"""{self._session.launcher.session_directory}""")\n'
+        jquery = ["jquery-3.4.1.min.js", "jquery.min.js"]
+        cmd = "import shutil, enve, ceiversion, os.path\n"
+        for script in jquery:
+            name = base_name + f"'{script}')"
+            cmd += "try:"
+            cmd += f'    shutil.copy({name}, r"""{self._session.launcher.session_directory}""")\n'
+            cmd += "except Exception:"
+            cmd += "    pass"
         name = "os.path.join(enve.home(), f'nexus{ceiversion.nexus_suffix}', 'django', "
         name += "'website', 'static', 'website', 'content', 'bootstrap.min.css')"
         cmd += f'shutil.copy({name}, r"""{self._session.launcher.session_directory}""")\n'


### PR DESCRIPTION
Philip is working on an upgrade of the jquery libraries. As part of this upgrade, he is conveniently dropping the jquery version from the script.
This is causing a failure in the PyEnSight tests since one of the tests tries to launch the deep pixel renderable, which triggers a copy of the old jquery libs in the websocketserved directory of the running pyensight session.

This PR adds a backdoor where both the versioned and unversioned scripts are tried.

While this is not ideal, it will work so that Philip can let his PR in. Once merged, a second PR on PyEnSight could be created where instead of trying both the libraries, we can first check the backend EnSight version, and if it is at least 251, the jquery script to be copied will be the unversioned one, the versioned one otherwise