### PR TITLE
Mostieri/remove requests limitation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "importlib-metadata>=4.0; python_version<='3.8'",
     "ansys-api-pyensight==0.4.1",
-    "requests>=2.28.2,<2.32",
+    "requests>=2.28.2",
     "docker>=6.1.0",
     "urllib3<2",
     "numpy>=1.21.0,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ tests = [
     "dill>=0.3.5.1",
     "pytest-mock==3.10.0",
     "urllib3==1.26.10",
-    "requests>=2.28.2,<2.32",
+    "requests>=2.28.2",
     "docker>=6.1.0",
 ]
 doc = [
@@ -63,7 +63,7 @@ doc = [
     "sphinxcontrib-mermaid==0.9.2",
     "docker>=6.1.0",
     "matplotlib==3.7.2",
-    "requests>=2.28.2,<2.32",
+    "requests>=2.28.2",
     "sphinxcontrib.jquery==4.1",
     "coverage-badge==1.1.0",
     "sphinxcontrib-openapi==0.8.1",


### PR DESCRIPTION
I added a while back a limitation on the requests package because of docker not supporting requests >= 2.32.
They got it fixed on their side, so we can fix it on ours.

This is needed to remove the limitation from the main pyansys metapackage