### PR TITLE
Mostieri/parallel runs avoid clash

### DIFF
--- a/src/ansys/pyensight/core/launcher.py
+++ b/src/ansys/pyensight/core/launcher.py
@@ -180,7 +180,7 @@ class Launcher:
         for process in psutil.process_iter():
             try:
                 process_cmdline = process.cmdline()
-            except psutil.AccessDenied:
+            except (psutil.AccessDenied, psutil.ZombieProcess):
                 continue
             if not process_cmdline:
                 continue

--- a/src/ansys/pyensight/core/launcher.py
+++ b/src/ansys/pyensight/core/launcher.py
@@ -13,6 +13,7 @@ Examples:
 """
 import os.path
 import platform
+import random
 import re
 import socket
 from typing import TYPE_CHECKING, Dict, List, Optional
@@ -225,7 +226,7 @@ class Launcher:
         ports = list()
 
         # pick a starting port number
-        start = os.getpid() % 64000
+        start = random.randint(1024, 64000)
         # We will scan for 65530 ports unless end is specified
         port_mod = 65530
         end = start + port_mod - 1

--- a/src/ansys/pyensight/core/locallauncher.py
+++ b/src/ansys/pyensight/core/locallauncher.py
@@ -123,7 +123,9 @@ class LocalLauncher(Launcher):
             self.session_directory = tempfile.mkdtemp(prefix="pyensight_")
 
             # gRPC port, VNC port, websocketserver ws, websocketserver html
-            self._ports = self._find_unused_ports(4)
+            to_avoid = self._find_ports_used_by_other_pyensight_and_ensight()
+            print(to_avoid)
+            self._ports = self._find_unused_ports(5, avoid=to_avoid)
             if self._ports is None:
                 raise RuntimeError("Unable to allocate local ports for EnSight session")
             is_windows = self._is_windows()
@@ -152,6 +154,7 @@ class LocalLauncher(Launcher):
             cmd.extend(["-grpc_server", str(self._ports[0])])
             vnc_url = f"vnc://%%3Frfb_port={self._ports[1]}%%26use_auth=0"
             cmd.extend(["-vnc", vnc_url])
+            cmd.extend(["-ports", str(self._ports[4])])
 
             use_egl = self._use_egl()
 

--- a/src/ansys/pyensight/core/locallauncher.py
+++ b/src/ansys/pyensight/core/locallauncher.py
@@ -124,7 +124,6 @@ class LocalLauncher(Launcher):
 
             # gRPC port, VNC port, websocketserver ws, websocketserver html
             to_avoid = self._find_ports_used_by_other_pyensight_and_ensight()
-            print(to_avoid)
             self._ports = self._find_unused_ports(5, avoid=to_avoid)
             if self._ports is None:
                 raise RuntimeError("Unable to allocate local ports for EnSight session")


### PR DESCRIPTION
In my attempt to run PyEnSight tests in parallel during the ADO builds, I am having several issues on linux where port clashes happen between the different PyEnSight sessions.

There are two clashes happening. I am not sure which of the two, but surely one of these:

1) EnSight is launched without the "-ports" argument with a newly found random port. I believe EnSight internally should try to do the Client/Server connection with ports between 1104 to 1119, but potentially that's an issue
2) This is the most likely. The find_unused_port code in multiple simultaneous runs may find the same free ports before these are being used for an actual connection, like the gRPC connection or the VNC connection

To avoid these issues, I have introduced an internal function which inspects the current processes and their command lines, so to build a list of ports to avoid to be fed into find_unused_ports.
Also, I am looking for an additional free port so to be used in the EnSight launch with "-ports" for the client/server connection. Finally, instead of using the pid of the process as starting point, I am using the random module. This workflow is being used only by the locallauncher

I have built the wheel and used it on one of the linux agents, the tests run correctly in parallel