### PR TITLE
remove urllib3 limitation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "ansys-api-pyensight==0.4.1",
     "requests>=2.28.2",
     "docker>=6.1.0",
-    "urllib3<2",
+    "urllib3<3.0.0",
     "numpy>=1.21.0,<2",
     "Pillow>=9.3.0",
     "pypng>=0.0.20",


### PR DESCRIPTION
I am not sure why it is there. Probably a remnant of the release process of PyEnSight