### PR TITLE
Point part handling

### DIFF
--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -32,8 +32,8 @@ class Part(object):
         self.normals = numpy.array([], dtype="float32")
         self.normals_elem = False
         self.tcoords = numpy.array([], dtype="float32")
-        self.tcoords_var_id: Optional[int] = None
         self.tcoords_elem = False
+        self.node_sizes = numpy.array([], dtype="float32")
         self.cmd: Optional[Any] = None
         self.reset()
 
@@ -46,6 +46,7 @@ class Part(object):
         self.tcoords = numpy.array([], dtype="float32")
         self.tcoords_var_id = None
         self.tcoords_elem = False
+        self.node_sizes = numpy.array([], dtype="float32")
         self.cmd = cmd
 
     def update_geom(self, cmd: dynamic_scene_graph_pb2.UpdateGeom) -> None:
@@ -83,17 +84,18 @@ class Part(object):
         ):
             # Get the variable definition
             if cmd.variable_id in self.session.variables:
-                self.tcoords_var_id = cmd.variable_id
-                self.tcoords_elem = (
-                    cmd.payload_type == dynamic_scene_graph_pb2.UpdateGeom.ELEM_VARIABLE
-                )
-                if self.tcoords.size != cmd.total_array_size:
-                    self.tcoords = numpy.resize(self.tcoords, cmd.total_array_size)
-                self.tcoords[
-                    cmd.chunk_offset : cmd.chunk_offset + len(cmd.flt_array)
-                ] = cmd.flt_array
-            else:
-                self.tcoords_var_id = None
+                if self.cmd.color_variableid == cmd.variable_id:
+                    # Receive the colorby var values
+                    self.tcoords_elem = (cmd.payload_type == dynamic_scene_graph_pb2.UpdateGeom.ELEM_VARIABLE)
+                    if self.tcoords.size != cmd.total_array_size:
+                        self.tcoords = numpy.resize(self.tcoords, cmd.total_array_size)
+                    self.tcoords[cmd.chunk_offset : cmd.chunk_offset + len(cmd.flt_array)] = cmd.flt_array
+                if self.cmd.node_size_variableid == cmd.variable_id:
+                    # Receive the node size var values
+                    if self.node_sizes.size != cmd.total_array_size:
+                        self.node_sizes = numpy.resize(self.node_sizes, cmd.total_array_size)
+                    self.node_sizes[cmd.chunk_offset : cmd.chunk_offset + len(cmd.flt_array)] = cmd.flt_array
+
 
     def nodal_surface_rep(self):
         """
@@ -120,26 +122,8 @@ class Part(object):
             self.session.log(f"Note: part '{self.cmd.name}' contains no triangles.")
             return None, None, None, None, None, None
         verts = self.coords
-        if self.session.normalize_geometry and self.session.scene_bounds is not None:
-            midx = (self.session.scene_bounds[3] + self.session.scene_bounds[0]) * 0.5
-            midy = (self.session.scene_bounds[4] + self.session.scene_bounds[1]) * 0.5
-            midz = (self.session.scene_bounds[5] + self.session.scene_bounds[2]) * 0.5
-            dx = self.session.scene_bounds[3] - self.session.scene_bounds[0]
-            dy = self.session.scene_bounds[4] - self.session.scene_bounds[1]
-            dz = self.session.scene_bounds[5] - self.session.scene_bounds[2]
-            s = dx
-            if dy > s:
-                s = dy
-            if dz > s:
-                s = dz
-            if s == 0:
-                s = 1.0
-            num_verts = int(verts.size / 3)
-            for i in range(num_verts):
-                j = i * 3
-                verts[j + 0] = (verts[j + 0] - midx) / s
-                verts[j + 1] = (verts[j + 1] - midy) / s
-                verts[j + 2] = (verts[j + 2] - midz) / s
+        self.normalize_verts(verts)
+
 
         conn = self.conn_tris
         normals = self.normals
@@ -242,6 +226,143 @@ class Part(object):
 
         return command, verts, conn, normals, tcoords, var_cmd
 
+
+    def normalize_verts(self, verts: numpy.ndarray):
+        """
+        This function scales and translates vertices, so the longest axis in the scene is of
+        length 1.0, and data is centered at the origin
+
+        Returns the scale factor
+        """
+        s = 1.0
+        if self.session.normalize_geometry and self.session.scene_bounds is not None:
+            num_verts = int(verts.size / 3)
+            midx = (self.session.scene_bounds[3] + self.session.scene_bounds[0]) * 0.5
+            midy = (self.session.scene_bounds[4] + self.session.scene_bounds[1]) * 0.5
+            midz = (self.session.scene_bounds[5] + self.session.scene_bounds[2]) * 0.5
+            dx = self.session.scene_bounds[3] - self.session.scene_bounds[0]
+            dy = self.session.scene_bounds[4] - self.session.scene_bounds[1]
+            dz = self.session.scene_bounds[5] - self.session.scene_bounds[2]
+            s = dx
+            if dy > s:
+                s = dy
+            if dz > s:
+                s = dz
+            if s == 0:
+                s = 1.0
+            for i in range(num_verts):
+                j = i * 3
+                verts[j + 0] = (verts[j + 0] - midx) / s
+                verts[j + 1] = (verts[j + 1] - midy) / s
+                verts[j + 2] = (verts[j + 2] - midz) / s
+        return 1.0/s
+
+    def point_rep(self):
+        """
+        This function processes the geometry arrays and returns values to represent point data
+
+        Returns
+        -------
+        On failure, the method returns None for the first return value.  The returned tuple is:
+
+        (part_command, vertices, sizes, colors, var_command)
+
+        part_command: UPDATE_PART command object
+        vertices: numpy array of per-node coordinates
+        sizes: numpy array of per-node radii
+        colors: numpy array of per-node rgb colors
+        var_command: UPDATE_VARIABLE command object for the variable the colors correspond to, if any
+        """
+        if self.cmd is None:
+            return None, None, None, None, None
+        if self.cmd.render != self.cmd.NODES:
+            # Early out.  Rendering type for this object is a surface rep, not a point rep
+            return None, None, None, None, None
+        verts = self.coords
+        num_verts = int(verts.size / 3)
+        norm_scale = self.normalize_verts(verts)
+        print(f"norm_scale = {norm_scale}")
+
+        # Convert var values in self.tcoords to RGB colors
+        # For now, look up RGB colors.  Planned USD enhancements should allow tex coords instead.
+        colors = None
+        var_cmd = None
+
+        if self.tcoords.size and self.tcoords.size==num_verts:
+            var_dsg_id = self.cmd.color_variableid
+            var_cmd = self.session.variables[var_dsg_id]
+            var_vals = self.tcoords
+            if len(var_cmd.levels)==0:
+                self.session.log(f"Note: Node rep not created for part '{self.cmd.name}'.  It has var values, but a palette with 0 levels.")
+                return None, None, None, None, None
+
+            p_min = None
+            p_max = None
+            for lvl in var_cmd.levels:
+                if (p_min is None) or (p_min > lvl.value):
+                    p_min = lvl.value
+                if (p_max is None) or (p_max < lvl.value):
+                    p_max = lvl.value
+            pal_minmax = [p_min, p_max]
+
+            num_texels = int(len(var_cmd.texture) / 4)
+
+            colors = numpy.ndarray((num_verts * 3,), dtype="float32")
+            low_color  = [ c/255.0 for c in var_cmd.texture[0:3] ]
+            high_color = [ c/255.0 for c in var_cmd.texture[4*(num_texels-1):4*(num_texels-1) + 3] ]
+            if p_min==p_max:
+                # Special case where palette min == palette max
+                mid_color = var_cmd[4*(num_texels//2):4*(num_texels//2) + 3]
+                for idx in range(num_verts):
+                    val = self.tcoords[idx]
+                    if val==p_min:
+                        colors[idx*3:idx*3+3] = mid_color
+                    elif val < p_min:
+                        colors[idx*3:idx*3+3] = low_color
+                    elif val > p_min:
+                        colors[idx*3:idx*3+3] = high_color
+            else:
+                for idx in range(num_verts):
+                    val = self.tcoords[idx]
+                    if val <= p_min:
+                        colors[idx*3:idx*3+3] = low_color
+                    else:
+                        pal_pos = (num_texels-1)*(val-p_min)/(p_max-p_min)
+                        pal_idx, pal_sub = divmod(pal_pos,1)
+                        pal_idx = int(pal_idx)
+
+                        if (pal_idx >= num_texels-1):
+                            colors[idx*3:idx*3+3] = high_color
+                        else:
+                            col0 = var_cmd.texture[pal_idx*4:pal_idx*4+3]
+                            col1 = var_cmd.texture[4+pal_idx*4:4+pal_idx*4+3]
+                            for ii in range(0,3):
+                                colors[idx*3+ii] = (col0[ii]*pal_sub+col1[ii]*(1.0-pal_sub))/255.0
+                #for idx in range(num_verts):
+                #    print(f"Val: {self.tcoords[idx]}: Color [{colors[idx*3]},{colors[idx*3+1]},{colors[idx*3+2]}]")
+            print(f"Part '{self.cmd.name}' defined: {self.coords.size/3} points.")
+
+        node_sizes = None
+        if self.node_sizes.size and self.node_sizes.size==num_verts:
+            # Pass out the node sizes if there is a size-by variable
+            node_size_default = self.cmd.node_size_default * norm_scale
+            node_sizes = numpy.ndarray((num_verts,), dtype="float32")
+            for ii in range(0,num_verts):
+                node_sizes[ii] = self.node_sizes[ii] * node_size_default
+        elif norm_scale != 1.0:
+            # Pass out the node sizes if the model is normalized to fit in a unit cube
+            node_size_default = self.cmd.node_size_default * norm_scale
+            node_sizes = numpy.ndarray((num_verts,), dtype="float32")
+            for ii in range(0,num_verts):
+                node_sizes[ii] = node_size_default
+            
+
+        self.session.log(
+            f"Part '{self.cmd.name}' defined: {self.coords.size/3} points."
+        )
+        command = self.cmd
+
+        return command, verts, node_sizes, colors, var_cmd
 
 class UpdateHandler(object):
     """
@@ -650,7 +771,7 @@ class DSGSession(object):
         self._callback_handler.finalize_part(self.part)
         self._mesh_block_count += 1
 
-    def _handle_part(self, part: Any) -> None:
+    def _handle_part(self, part_cmd: Any) -> None:
         """Handle a DSG UPDATE_PART command
 
         Finish the current part and set up the next part.
@@ -661,7 +782,7 @@ class DSGSession(object):
             The command coming from the EnSight stream.
         """
         self._finish_part()
-        self._part.reset(part)
+        self._part.reset(part_cmd)
 
     def _handle_group(self, group: Any) -> None:
         """Handle a DSG UPDATE_GROUP command

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List, Optional
 
 import omni.client
 import png
-from pxr import Gf, Sdf, Usd, UsdGeom, UsdLux, UsdShade, Vt
+from pxr import Gf, Sdf, Usd, UsdGeom, UsdLux, UsdShade
 
 sys.path.append(os.path.dirname(__file__))
 from dsg_server import DSGSession, Part, UpdateHandler  # noqa: E402
@@ -369,8 +369,9 @@ class OmniverseWrapper:
 
         return part_stage_url
 
-
-    def add_timestep_group(self, parent_prim: UsdGeom.Xform, timeline: List[float], first_timestep: bool) -> UsdGeom.Xform:
+    def add_timestep_group(
+        self, parent_prim: UsdGeom.Xform, timeline: List[float], first_timestep: bool
+    ) -> UsdGeom.Xform:
         # add a layer in the group hierarchy for the timestep
         timestep_group_path = parent_prim.GetPath().AppendChild(
             self.clean_name("t" + str(timeline[0]), None)
@@ -386,7 +387,6 @@ class OmniverseWrapper:
         if timeline[0] < timeline[1]:
             visibility_attr.Set("invisible", timeline[1])
         return timestep_prim
-
 
     def create_dsg_points(
         self,
@@ -412,19 +412,19 @@ class OmniverseWrapper:
         xform = UsdGeom.Xform.Define(part_stage, "/" + partname)
 
         points = UsdGeom.Points.Define(part_stage, "/" + partname + "/Points")
-        #points.GetPointsAttr().Set(Vt.Vec3fArray(verts.tolist()))
+        # points.GetPointsAttr().Set(Vt.Vec3fArray(verts.tolist()))
         points.GetPointsAttr().Set(verts)
-        if sizes is not None and sizes.size == (verts.size//3):
+        if sizes is not None and sizes.size == (verts.size // 3):
             points.GetWidthsAttr().Set(sizes)
         else:
-            points.GetWidthsAttr().Set([default_size]*(verts.size//3))
+            points.GetWidthsAttr().Set([default_size] * (verts.size // 3))
 
         colorAttr = points.GetPrim().GetAttribute("primvars:displayColor")
         colorAttr.SetMetadata("interpolation", "vertex")
         if colors is not None and colors.size == verts.size:
             colorAttr.Set(colors)
         else:
-            colorAttr.Set([default_color[0:3]]*(verts.size//3))
+            colorAttr.Set([default_color[0:3]] * (verts.size // 3))
 
         part_prim = part_stage.GetPrimAtPath("/" + partname)
         part_stage.SetDefaultPrim(part_prim)
@@ -444,7 +444,6 @@ class OmniverseWrapper:
         part_stage.GetRootLayer().Save()
 
         return part_stage_url
-
 
     def create_dsg_material(
         self, stage, mesh, root_name, diffuse=[1.0, 1.0, 1.0, 1.0], variable=None
@@ -749,7 +748,7 @@ class OmniverseUpdateHandler(UpdateHandler):
 
     def finalize_part(self, part: Part) -> None:
         # generate an Omniverse compliant mesh from the Part
-        #if part.cmd:
+        # if part.cmd:
         #    print(f"Part {part.cmd.name} Points: {part.coords.size} Var values: {part.tcoords.size} Node sizes: {part.node_sizes.size}")
         #    for s in part.node_sizes:
         #        print(f"{s}")
@@ -782,7 +781,8 @@ class OmniverseUpdateHandler(UpdateHandler):
                     diffuse=color,
                     variable=var_cmd,
                     timeline=self.session.cur_timeline,
-                    first_timestep=(self.session.cur_timeline[0] == self.session.time_limits[0]),)
+                    first_timestep=(self.session.cur_timeline[0] == self.session.time_limits[0]),
+                )
 
         elif part.cmd.render == part.cmd.NODES:
             command, verts, sizes, colors, var_cmd = part.point_rep()
@@ -798,7 +798,8 @@ class OmniverseUpdateHandler(UpdateHandler):
                     default_size=part.cmd.node_size_default,
                     default_color=color,
                     timeline=self.session.cur_timeline,
-                    first_timestep=(self.session.cur_timeline[0] == self.session.time_limits[0]),)
+                    first_timestep=(self.session.cur_timeline[0] == self.session.time_limits[0]),
+                )
         super().finalize_part(part)
 
     def start_connection(self) -> None:

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List, Optional
 
 import omni.client
 import png
-from pxr import Gf, Sdf, Usd, UsdGeom, UsdLux, UsdShade
+from pxr import Gf, Sdf, Usd, UsdGeom, UsdLux, UsdShade, Vt
 
 sys.path.append(os.path.dirname(__file__))
 from dsg_server import DSGSession, Part, UpdateHandler  # noqa: E402
@@ -358,6 +358,19 @@ class OmniverseWrapper:
             part_stage, mesh, "/" + partname, diffuse=diffuse, variable=variable
         )
 
+        timestep_prim = self.add_timestep_group(parent_prim, timeline, first_timestep)
+
+        # glue it into our stage
+        path = timestep_prim.GetPath().AppendChild("part_ref_" + partname)
+        part_ref = self._stage.OverridePrim(path)
+        part_ref.GetReferences().AddReference("." + stage_name)
+
+        part_stage.GetRootLayer().Save()
+
+        return part_stage_url
+
+
+    def add_timestep_group(self, parent_prim: UsdGeom.Xform, timeline: List[float], first_timestep: bool) -> UsdGeom.Xform:
         # add a layer in the group hierarchy for the timestep
         timestep_group_path = parent_prim.GetPath().AppendChild(
             self.clean_name("t" + str(timeline[0]), None)
@@ -372,6 +385,56 @@ class OmniverseWrapper:
         # Final timestep has timeline[0]==timeline[1].  Leave final timestep visible.
         if timeline[0] < timeline[1]:
             visibility_attr.Set("invisible", timeline[1])
+        return timestep_prim
+
+
+    def create_dsg_points(
+        self,
+        name,
+        id,
+        parent_prim,
+        verts,
+        sizes,
+        colors,
+        matrix=[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        default_size=1.0,
+        default_color=[1.0, 1.0, 1.0, 1.0],
+        timeline=[0.0, 0.0],
+        first_timestep=False,
+    ):
+        # create the part usd object
+        partname = self.clean_name(name + str(id) + str(timeline[0]))
+        stage_name = "/Parts/" + partname + ".usd"
+        part_stage_url = self.stage_url(stage_name)
+        omni.client.delete(part_stage_url)
+        part_stage = Usd.Stage.CreateNew(part_stage_url)
+        self._old_stages.append(part_stage_url)
+        xform = UsdGeom.Xform.Define(part_stage, "/" + partname)
+
+        points = UsdGeom.Points.Define(part_stage, "/" + partname + "/Points")
+        #points.GetPointsAttr().Set(Vt.Vec3fArray(verts.tolist()))
+        points.GetPointsAttr().Set(verts)
+        if sizes is not None and sizes.size == (verts.size//3):
+            points.GetWidthsAttr().Set(sizes)
+        else:
+            points.GetWidthsAttr().Set([default_size]*(verts.size//3))
+
+        colorAttr = points.GetPrim().GetAttribute("primvars:displayColor")
+        colorAttr.SetMetadata("interpolation", "vertex")
+        if colors is not None and colors.size == verts.size:
+            colorAttr.Set(colors)
+        else:
+            colorAttr.Set([default_color[0:3]]*(verts.size//3))
+
+        part_prim = part_stage.GetPrimAtPath("/" + partname)
+        part_stage.SetDefaultPrim(part_prim)
+
+        # Currently, this will never happen, but it is a setup for rigid body transforms
+        # At present, the group transforms have been cooked into the vertices so this is not needed
+        matrixOp = xform.AddXformOp(UsdGeom.XformOp.TypeTransform, UsdGeom.XformOp.PrecisionDouble)
+        matrixOp.Set(Gf.Matrix4d(*matrix).GetTranspose())
+
+        timestep_prim = self.add_timestep_group(parent_prim, timeline, first_timestep)
 
         # glue it into our stage
         path = timestep_prim.GetPath().AppendChild("part_ref_" + partname)
@@ -381,6 +444,7 @@ class OmniverseWrapper:
         part_stage.GetRootLayer().Save()
 
         return part_stage_url
+
 
     def create_dsg_material(
         self, stage, mesh, root_name, diffuse=[1.0, 1.0, 1.0, 1.0], variable=None
@@ -685,34 +749,56 @@ class OmniverseUpdateHandler(UpdateHandler):
 
     def finalize_part(self, part: Part) -> None:
         # generate an Omniverse compliant mesh from the Part
-        command, verts, conn, normals, tcoords, var_cmd = part.nodal_surface_rep()
-        if command is None:
+        #if part.cmd:
+        #    print(f"Part {part.cmd.name} Points: {part.coords.size} Var values: {part.tcoords.size} Node sizes: {part.node_sizes.size}")
+        #    for s in part.node_sizes:
+        #        print(f"{s}")
+        if part is None or part.cmd is None:
             return
-        parent_prim = self._group_prims[command.parent_id]
+        parent_prim = self._group_prims[part.cmd.parent_id]
         obj_id = self.session.mesh_block_count
-        matrix = command.matrix4x4
-        name = command.name
+        matrix = part.cmd.matrix4x4
+        name = part.cmd.name
         color = [
-            command.fill_color[0] * command.diffuse,
-            command.fill_color[1] * command.diffuse,
-            command.fill_color[2] * command.diffuse,
-            command.fill_color[3],
+            part.cmd.fill_color[0] * part.cmd.diffuse,
+            part.cmd.fill_color[1] * part.cmd.diffuse,
+            part.cmd.fill_color[2] * part.cmd.diffuse,
+            part.cmd.fill_color[3],
         ]
-        # Generate the mesh block
-        _ = self._omni.create_dsg_mesh_block(
-            name,
-            obj_id,
-            parent_prim,
-            verts,
-            conn,
-            normals,
-            tcoords,
-            matrix=matrix,
-            diffuse=color,
-            variable=var_cmd,
-            timeline=self.session.cur_timeline,
-            first_timestep=(self.session.cur_timeline[0] == self.session.time_limits[0]),
-        )
+
+        if part.cmd.render == part.cmd.CONNECTIVITY:
+            command, verts, conn, normals, tcoords, var_cmd = part.nodal_surface_rep()
+            if command is not None:
+                # Generate the mesh block
+                _ = self._omni.create_dsg_mesh_block(
+                    name,
+                    obj_id,
+                    parent_prim,
+                    verts,
+                    conn,
+                    normals,
+                    tcoords,
+                    matrix=matrix,
+                    diffuse=color,
+                    variable=var_cmd,
+                    timeline=self.session.cur_timeline,
+                    first_timestep=(self.session.cur_timeline[0] == self.session.time_limits[0]),)
+
+        elif part.cmd.render == part.cmd.NODES:
+            command, verts, sizes, colors, var_cmd = part.point_rep()
+            if command is not None:
+                _ = self._omni.create_dsg_points(
+                    name,
+                    obj_id,
+                    parent_prim,
+                    verts,
+                    sizes,
+                    colors,
+                    matrix=matrix,
+                    default_size=part.cmd.node_size_default,
+                    default_color=color,
+                    timeline=self.session.cur_timeline,
+                    first_timestep=(self.session.cur_timeline[0] == self.session.time_limits[0]),)
         super().finalize_part(part)
 
     def start_connection(self) -> None:


### PR DESCRIPTION
Handle the node size-by variable in the base dsg_server Part class.  Create Omniverse spheres from points.

I removed the tcoords_var_id from the Part class.  It was not being used, and the ID is also stored in part.cmd.color_variableid.
I believe EnSight 24.2 sends the points and default point size, but not the size-by var values.  An EnSight PR to be created shortly will send the size-by var values.