### PR TITLE
fix live DVS when launcher does not exist

### DIFF
--- a/src/ansys/pyensight/core/utils/readers.py
+++ b/src/ansys/pyensight/core/utils/readers.py
@@ -10,8 +10,6 @@ from types import ModuleType
 from typing import Optional, Tuple, Union
 import uuid
 
-from ansys.pyensight.core import LocalLauncher
-
 try:
     import ensight
 except ImportError:
@@ -105,15 +103,20 @@ class DVS:
         """Find the dvs port allocated from the input temporary name"""
         if not tmp_name:
             raise RuntimeError("Temporary name for dvs port file not available")
-        is_local = isinstance(self._ensight._session._launcher, LocalLauncher)
-        if is_local:
-            with open(tmp_name) as dvs_port_file:
-                self._dvs_port = int(dvs_port_file.read().strip())
-        else:
-            log_content = self._ensight._session._launcher.enshell_log_contents()
-            dvs_port_match = re.search(r"\(0.0.0.0\):([0-9]{4,5})\n", log_content)
-            if dvs_port_match:
-                self._dvs_port = int(str(dvs_port_match.groups(1)[0]).strip())
+        try_local = True
+        if self._ensight._session._launcher:
+            if hasattr(self._ensight._session._launcher, "_enshell"):
+                try_local = False
+                log_content = self._ensight._session._launcher.enshell_log_contents()
+                dvs_port_match = re.search(r"\(0.0.0.0\):([0-9]{4,5})\n", log_content)
+                if dvs_port_match:
+                    self._dvs_port = int(str(dvs_port_match.groups(1)[0]).strip())
+        if try_local:
+            try:
+                with open(tmp_name) as dvs_port_file:
+                    self._dvs_port = int(dvs_port_file.read().strip())
+            except Exception:
+                raise RuntimeError("Cannot retrieve DVS Port")
 
     @staticmethod
     def _launch_dvs_callback_in_ensight(


### PR DESCRIPTION
When launching the webui PyEnSight asks EnSight to launch the simba plugin.
As part of this process a new PyEnSight session, clone of the existing one, is launched on the python process that is launching simba.
This session, being a clone, has no Launcher object associated.

The live DVS interface I designed didn't consider this scenario, always relying on the launcher instance (local or docker) to choose how to get the DVS port from the temp file where it is stored. This caused the code to use the docker approach even if the clone session is always launched local to the EnSight install, so via the LocalLauncher

This PR fixes it. I am now detecting if we are using DockerLauncher by looking at the _enshell object availability, and always try the Local approach if the "_enshell" object is not available (LocalLauncher) or the Launcher object is not available at all