### PR TITLE
Add Enum docs to libuserd

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,12 @@
+# This is the list of PyAEDT significant contributors.
+#
+# This file does not necessarily list everyone who has contributed code.
+#
+# For contributions made under a Corporate CLA, the organization is
+# added to this file.
+#
+# If you have contributed to the repository and want to be added to this file,
+# submit a request.
+#
+#
+ANSYS, Inc.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,13 @@
+# Contributors
+
+## Project Lead
+
+* [Mario Ostieri](https://github.com/mariostieriansys)
+
+## Individual Contributors
+
+* [Mario Ostieri](https://github.com/mariostieriansys)
+* [Randy Frank](https://github.com/randallfrank)
+* [Kevin Colburn](https://github.com/kecolburn)
+* [David Bremer](https://github.com/david-bremer)
+* [Mike Krogh](https://github.com/mfkrogh)

--- a/doc/source/libuserd_documentation.rst
+++ b/doc/source/libuserd_documentation.rst
@@ -29,6 +29,12 @@ uses a USERD interface can be read using this API.
    ansys.pyensight.core.libuserd.ReaderInfo
    ansys.pyensight.core.libuserd.Reader
    ansys.pyensight.core.libuserd.Part
+   ansys.pyensight.core.libuserd.PartHints
+   ansys.pyensight.core.libuserd.ElementType
    ansys.pyensight.core.libuserd.Variable
+   ansys.pyensight.core.libuserd.VariableType
+   ansys.pyensight.core.libuserd.VariableLocation
    ansys.pyensight.core.libuserd.Query
    ansys.pyensight.core.libuserd.LibUserdError
+   ansys.pyensight.core.libuserd.ErrorCodes
+

--- a/src/ansys/pyensight/core/libuserd.py
+++ b/src/ansys/pyensight/core/libuserd.py
@@ -63,20 +63,20 @@ warnings.warn(
 )
 
 
-def _build_enum(name: str, pb_enum: Any) -> enum.IntEnum:
+def _build_enum(name: str, pb_enum: Any, flag: bool = False) -> Union[enum.IntEnum, enum.IntFlag]:
     values = {}
     for v in pb_enum:
         values[v[0]] = v[1]
+    if flag:
+        return enum.IntFlag(name, values)
     return enum.IntEnum(name, values)
 
 
-ErrorCodes: enum.IntEnum = _build_enum("ErrorCodes", libuserd_pb2.ErrorCodes.items())
-ElementType: enum.IntEnum = _build_enum("ElementType", libuserd_pb2.ElementType.items())
-VariableLocation: enum.IntEnum = _build_enum(
-    "VariableLocation", libuserd_pb2.VariableLocation.items()
-)
-VariableType: enum.IntEnum = _build_enum("VariableType", libuserd_pb2.VariableType.items())
-PartHints: enum.IntEnum = _build_enum("PartHints", libuserd_pb2.PartHints.items())
+ErrorCodes = _build_enum("ErrorCodes", libuserd_pb2.ErrorCodes.items())
+ElementType = _build_enum("ElementType", libuserd_pb2.ElementType.items())
+VariableLocation = _build_enum("VariableLocation", libuserd_pb2.VariableLocation.items())
+VariableType = _build_enum("VariableType", libuserd_pb2.VariableType.items())
+PartHints = _build_enum("PartHints", libuserd_pb2.PartHints.items(), flag=True)
 
 
 class LibUserdError(Exception):


### PR DESCRIPTION
Move the enums from the LibUser class (leave them them for backward compatibility), to the module and document them as such.