### PR TITLE
Remove PyAEDT from text

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the list of PyAEDT significant contributors.
+# This is the list of significant contributors to this repository.
 #
 # This file does not necessarily list everyone who has contributed code.
 #


### PR DESCRIPTION
Use the generic form of the authors file.