### PR TITLE
Revert "make session launch common and add three attempts to run the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,4 @@ pyensight_test_results.xml
 venv/
 .vscode/
 .venv/
-*.glb
-*.csv
-*.ctxz
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,27 +140,3 @@ def mocked_session(mocker, tmpdir, enshell_mock) -> "Session":
     session._build_utils_interface()
     session._cei_suffix = "345"
     return session
-
-
-@pytest.fixture
-def launch_pyensight_session(tmpdir, pytestconfig: pytest.Config):
-    data_dir = tmpdir.mkdir("datadir")
-    use_local = pytestconfig.getoption("use_local_launcher")
-    root = None
-    if use_local:
-        root = "http://s3.amazonaws.com/www3.ensight.com/PyEnSight/ExampleData"
-    if use_local:
-        launcher = LocalLauncher(enable_rest_api=True)
-    else:
-        launcher = DockerLauncher(data_directory=data_dir, use_dev=True, enable_rest_api=True)
-    counter = 0
-    working = False
-    session = None
-    while not working and counter < 4:
-        try:
-            session = launcher.start()
-            working = True
-            break
-        except Exception:
-            counter += 1
-    return session, data_dir, root

--- a/tests/example_tests/test_asynchronous_events.py
+++ b/tests/example_tests/test_asynchronous_events.py
@@ -14,15 +14,21 @@ with different mechanisms for getting data values.
 # Start by launching and connecting to an instance of EnSight.
 # In this case, we use a local installation of EnSight.
 
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 from urllib.parse import parse_qs, urlparse
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
+from ansys.pyensight.core.dockerlauncher import DockerLauncher
+from ansys.pyensight.core.locallauncher import LocalLauncher
+import pytest
 
 
-def test_async_events(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, data_dir, _ = launch_pyensight_session
+def test_async_events(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
+        launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     ###############################################################################
     # Simple event
     # ------------

--- a/tests/example_tests/test_basic_usage.py
+++ b/tests/example_tests/test_basic_usage.py
@@ -1,13 +1,18 @@
 import glob
 import os
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
+from ansys.pyensight.core import DockerLauncher, LocalLauncher
+import pytest
 
 
-def test_basic_usage(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, data_dir, _ = launch_pyensight_session
+def test_basic_usage(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
+        launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     core = session.ensight.objs.core
     session.load_data(f"{session.cei_home}/ensight{session.cei_suffix}/data/cube/cube.case")
     session.ensight.view_transf.rotate(30, 30, 0)

--- a/tests/example_tests/test_coverage_increase.py
+++ b/tests/example_tests/test_coverage_increase.py
@@ -1,25 +1,28 @@
 import os
 import pathlib
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-from ansys.pyensight.core import launch_ensight
+from ansys.pyensight.core import DockerLauncher, LocalLauncher, launch_ensight
 from ansys.pyensight.core.enscontext import EnsContext
 from ansys.pyensight.core.utils.parts import convert_part, convert_variable
 from ansys.pyensight.core.utils.variables import vec_mag
 import pytest
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
 
-
-def test_coverage_increase(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, data_dir, root = launch_pyensight_session
-    use_local = not hasattr(session._launcher, "_enshell")
+def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    root = None
+    if use_local:
+        launcher = LocalLauncher()
+        root = "http://s3.amazonaws.com/www3.ensight.com/PyEnSight/ExampleData"
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     if not use_local:
-        session._launcher._enshell.host
-        session._launcher._enshell.port
-        session._launcher._enshell.run_command("printenv")
-        session._launcher._enshell.run_command_with_env("printenv", "ENSIGHT_ANSYS_ALPHA_FLAG=1")
+        launcher._enshell.host
+        launcher._enshell.port
+        launcher._enshell.run_command("printenv")
+        launcher._enshell.run_command_with_env("printenv", "ENSIGHT_ANSYS_ALPHA_FLAG=1")
     with open(os.path.join(data_dir, "test_exec_run_script.py"), "w") as _file:
         _file.write("")
     os.mkdir(os.path.join(data_dir, "test_dir"))
@@ -293,7 +296,7 @@ def test_coverage_increase(launch_pyensight_session: Tuple["Session", Any, Optio
     str(session.ensight.objs.core.PARTS[0])
     str(session.ensight.objs.core.TEXTURES[0])
     if not use_local:
-        session._launcher.enshell_log_contents()
+        launcher.enshell_log_contents()
     assert session.ensight.objs.core.PARTS[0] != session.ensight.objs.core.PARTS[1]
     cas_file = session.download_pyansys_example("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
     dat_file = session.download_pyansys_example("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
@@ -312,10 +315,16 @@ def test_coverage_increase(launch_pyensight_session: Tuple["Session", Any, Optio
     session.close()
 
 
-def test_particle_traces_and_geometry(
-    launch_pyensight_session: Tuple["Session", Any, Optional[str]]
-):
-    session, _, root = launch_pyensight_session
+def test_particle_traces_and_geometry(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    root = None
+    if use_local:
+        launcher = LocalLauncher(enable_rest_api=True)
+        root = "http://s3.amazonaws.com/www3.ensight.com/PyEnSight/ExampleData"
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True, enable_rest_api=True)
+    session = launcher.start()
     session.load_example("waterbreak.ens", root=root)
     session.show("webensight")
     session.show("webgl")
@@ -401,15 +410,22 @@ def test_particle_traces_and_geometry(
     temp_part.destroy()
 
 
-def test_sos(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, data_dir, root = launch_pyensight_session
-    use_local = not hasattr(session._launcher, "_enshell")
+def test_sos(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    is_docker = False
+    if use_local:
+        launcher = LocalLauncher(use_sos=2)
+    else:
+        is_docker = True
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True, use_sos=2)
+    session = launcher.start()
     session.load_data(f"{session.cei_home}/ensight{session.cei_suffix}/data/cube/cube.case")
     assert session.grpc.port() == session._grpc_port
     assert session.grpc.host == session._hostname
     assert session.grpc.security_token == session._secret_key
     session.close()
-    if not use_local:
+    if is_docker:
         session = launch_ensight(use_docker=True, use_dev=True, data_directory=data_dir)
         assert session._launcher._enshell.host() == session._hostname
         session._launcher._enshell.port()

--- a/tests/example_tests/test_designpoints.py
+++ b/tests/example_tests/test_designpoints.py
@@ -1,14 +1,20 @@
 import glob
 import os
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
+from ansys.pyensight.core import DockerLauncher, LocalLauncher
+import pytest
 
 
-def test_designpoints(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, data_dir, root = launch_pyensight_session
-
+def test_designpoints(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    root = None
+    if use_local:
+        launcher = LocalLauncher()
+        root = "http://s3.amazonaws.com/www3.ensight.com/PyEnSight/ExampleData"
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     session.load_example("elbow_dp0_dp1.ens", root=root)
     image = session.show("image", width=800, height=600)
     image.download(data_dir)

--- a/tests/example_tests/test_force_tool.py
+++ b/tests/example_tests/test_force_tool.py
@@ -1,10 +1,10 @@
 import math
 import os
 import time
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
+from ansys.pyensight.core.dockerlauncher import DockerLauncher
+from ansys.pyensight.core.locallauncher import LocalLauncher
+import pytest
 
 
 def create_frame(ensight):
@@ -43,9 +43,14 @@ def create_frame(ensight):
     ensight.frame.assign(0)
 
 
-def test_force_tool(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, _, _ = launch_pyensight_session
-    use_local = not hasattr(session._launcher, "_enshell")
+def test_force_tool(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
+        launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     path = None
     if use_local:
         path = f"{session.cei_home}/ensight{session.cei_suffix}/data/RC_Plane/"

--- a/tests/example_tests/test_queries.py
+++ b/tests/example_tests/test_queries.py
@@ -1,16 +1,23 @@
 import glob
 from operator import attrgetter
 import os
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
-
+from ansys.pyensight.core.dockerlauncher import DockerLauncher
+from ansys.pyensight.core.locallauncher import LocalLauncher
 import numpy as np
+import pytest
 
 
-def test_queries(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, data_dir, root = launch_pyensight_session
+def test_queries(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    root = None
+    if use_local:
+        launcher = LocalLauncher()
+        root = "http://s3.amazonaws.com/www3.ensight.com/PyEnSight/ExampleData"
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     session.load_example("waterbreak.ens", root=root)
     # Get the core part and variable objects
     var = session.ensight.objs.core.VARIABLES["p"][0]

--- a/tests/example_tests/test_remote_objects.py
+++ b/tests/example_tests/test_remote_objects.py
@@ -1,12 +1,17 @@
 import gc
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
+from ansys.pyensight.core import DockerLauncher, LocalLauncher
+import pytest
 
 
-def test_remote_objects(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, _, _ = launch_pyensight_session
+def test_remote_objects(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
+        launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     session.load_data(f"{session.cei_home}/ensight{session.cei_suffix}/data/guard_rail/crash.case")
 
     # call __str__ on an ENSOBJ object w/o DESCRIPTION attribute (for coverage)

--- a/tests/example_tests/test_renderables.py
+++ b/tests/example_tests/test_renderables.py
@@ -1,13 +1,18 @@
 import glob
 import os
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
+from ansys.pyensight.core import DockerLauncher, LocalLauncher
+import pytest
 
 
-def test_renderables(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, data_dir, _ = launch_pyensight_session
+def test_renderables(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
+        launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     session.load_data(f"{session.cei_home}/ensight{session.cei_suffix}/data/guard_rail/crash.case")
     # Apply displacements
     displacement = session.ensight.objs.core.VARIABLES["displacement"][0]

--- a/tests/example_tests/test_rest_api.py
+++ b/tests/example_tests/test_rest_api.py
@@ -1,13 +1,18 @@
-from typing import TYPE_CHECKING, Any, Optional, Tuple
-
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
-
+from ansys.pyensight.core.dockerlauncher import DockerLauncher
+from ansys.pyensight.core.locallauncher import LocalLauncher
+import pytest
 import requests
 
 
-def test_rest_apis(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    s, _, _ = launch_pyensight_session
+def test_rest_apis(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
+        launcher = LocalLauncher(enable_rest_api=True)
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True, enable_rest_api=True)
+
+    s = launcher.start()
     s.load_data(f"{s.cei_home}/ensight{s.cei_suffix}/data/cube/cube.case")
     uri_base = f"http://{s.hostname}:{s.html_port}/ensight/v1/{s.secret_key}"
 

--- a/tests/example_tests/test_usd_export.py
+++ b/tests/example_tests/test_usd_export.py
@@ -1,12 +1,10 @@
 import glob
 import os
 import time
-from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-if TYPE_CHECKING:
-    from ansys.pyensight.core import Session
-
+from ansys.pyensight.core import DockerLauncher, LocalLauncher
 from pxr import Usd
+import pytest
 
 
 def compare_prims(prim1, prim2):
@@ -48,8 +46,14 @@ def wait_for_idle(session):
     return found
 
 
-def test_usd_export(launch_pyensight_session: Tuple["Session", Any, Optional[str]]):
-    session, data_dir, _ = launch_pyensight_session
+def test_usd_export(tmpdir, pytestconfig: pytest.Config):
+    data_dir = tmpdir.mkdir("datadir")
+    use_local = pytestconfig.getoption("use_local_launcher")
+    if use_local:
+        launcher = LocalLauncher()
+    else:
+        launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
+    session = launcher.start()
     session.load_example("waterbreak.ens")
     session.ensight.utils.omniverse.create_connection(data_dir)
     assert wait_for_idle(session)


### PR DESCRIPTION
This reverts commit 627e2640d469276828f61f6385eeb62ddb8f7562.

This commit is the reason of the slowdown of the PyEnSight tests in ADO. So for the moment being I am just reverting it
I am not sure yet why the slowdown is happening, so for the moment being it is just quicker to revert this change