### PR TITLE
move parallel settings to workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           requires-xvfb: true
+          pytest-extra-args: "-n 4 -reruns 3"
 
       - uses: codecov/codecov-action@v3
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           requires-xvfb: true
-          pytest-extra-args: "-n 4 -reruns 3"
+          pytest-extra-args: "-n 4 --reruns 3"
 
       - uses: codecov/codecov-action@v3
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           requires-xvfb: true
+          pytest-extra-args: "-n 4 -reruns 3"
 
       - uses: codecov/codecov-action@v3
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           requires-xvfb: true
-          pytest-extra-args: "-n 4 -reruns 3"
+          pytest-extra-args: "-n 4 --reruns 3"
 
       - uses: codecov/codecov-action@v3
         name: 'Upload coverage to CodeCov'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ minversion = "7.1"
 testpaths = [
     "tests",
 ]
-addopts = "-n 4 --reruns 3 --setup-show --cov=ansys.pyensight.core --cov-report html:coverage-html --cov-report term --cov-config=.coveragerc --capture=tee-sys --tb=native -p no:warnings"
+addopts = "--setup-show --cov=ansys.pyensight.core --cov-report html:coverage-html --cov-report term --cov-config=.coveragerc --capture=tee-sys --tb=native -p no:warnings"
 markers =[
     "integration:Run integration tests",
     "smoke:Run the smoke tests",


### PR DESCRIPTION
There's an annoying issue when running even only on pytest locally where the config is being picked up from the toml.

This was fine but now that parallel is hardcoded, pytest is trying to run always in parallel. So, if you run one test only, it will launch it 4 times

The trick is to remove the parallel settings from the toml and make them workflow args