### PR TITLE
Fix deep pixel renderables for 2025 R1

### DIFF
--- a/src/ansys/pyensight/core/deep_pixel_view.html
+++ b/src/ansys/pyensight/core/deep_pixel_view.html
@@ -76,15 +76,15 @@
 		<div style="margin: 0 auto; display:flex; justify-content:center;">
 			<!-- tooltip parent for img --->
 			<div id="probe_display_ITEMID"
-				 data-toggle="tooltip"
-				 data-placement="bottom"
-				 data-fallbackPlacement="['top', 'right']"
-				 data-html="true"
-				 data-container="body"
-				 data-boundary="viewport"
-				 data-animation="false"
-				 data-trigger="manual"
-				 data-title='<span class="f-1r">
+				 data-BS_PREFIXtoggle="tooltip"
+				 data-BS_PREFIXplacement="bottom"
+				 data-BS_PREFIXfallbackPlacement="['top', 'right']"
+				 data-BS_PREFIXhtml="true"
+				 data-BS_PREFIXcontainer="body"
+				 data-BS_PREFIXboundary="viewport"
+				 data-BS_PREFIXanimation="false"
+				 data-BS_PREFIXtrigger="manual"
+				 data-BS_PREFIXtitle='<span class="f-1r">
 											<span>X, Y : <span id="probe_xy_ITEMID">0, 0</span></span>
 											<br>
 											<span id="probe_result_ITEMID"></span>

--- a/src/ansys/pyensight/core/renderable.py
+++ b/src/ansys/pyensight/core/renderable.py
@@ -393,8 +393,11 @@ class RenderableDeepPixel(Renderable):
         name += "'website', 'static', 'website', 'content', 'bootstrap.min.css')"
         cmd += f'shutil.copy({name}, r"""{self._session.launcher.session_directory}""")\n'
         self._session.cmd(cmd, do_eval=False)
+        # With Bootstrap 5 (2025 R1), class names have '-bs-' in them, e.g. 'data-bs-toggle' vs 'data-toggle'
+        bs_prefix = "bs-"
         jquery_version = ""
         if int(self._session._cei_suffix) < 251:
+            bs_prefix = ""
             jquery_version = "-3.4.1"
         jquery = f"jquery{jquery_version}.min.js"
         cmd = "import shutil, enve, ceiversion, os.path\n"
@@ -414,6 +417,7 @@ class RenderableDeepPixel(Renderable):
         html = html.replace("ITEMID", self._guid)
         html = html.replace("OPTIONAL_QUERY", optional_query)
         html = html.replace("JQUERY_VERSION", jquery_version)
+        html = html.replace("BS_PREFIX", bs_prefix)
         # refresh the remote HTML
         self._save_remote_html_page(html)
         super().update()


### PR DESCRIPTION
Changes in ADR bootstrap broke the deep pixels renderable.   Fix up div classnames for bootstrap 5.x.