### PR TITLE
make default value of install path None and add EnSight install case in libuserd search for install

### DIFF
--- a/src/ansys/pyensight/core/libuserd.py
+++ b/src/ansys/pyensight/core/libuserd.py
@@ -1330,6 +1330,13 @@ class LibUserd(object):
             # ways, we'll add that one too, just in case.
             dirs_to_check.append(os.path.join(env_inst, "CEI"))
 
+        try:
+            import enve
+
+            dirs_to_check.append(enve.home())
+        except ModuleNotFoundError:
+            pass
+
         if "CEI_HOME" in os.environ:
             env_inst = os.environ["CEI_HOME"]
             dirs_to_check.append(env_inst)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,11 +21,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     $ pytest tests --install-path "/ansys_inc/v231/CEI/bin/ensight"
     TODO: Default must be set to the one on the CI/CD server.
     """
-    parser.addoption(
-        "--install-path",
-        action="store",
-        default=f"/ansys_inc/v{ansys.pyensight.core.__ansys_version__}/",
-    )
+    parser.addoption("--install-path", action="store")
     parser.addoption("--use-local-launcher", default=False, action="store_true")
 
 


### PR DESCRIPTION
Two issues:

1. The install path value in the Pytest parser was "/ansys_inc/v{version}/CEI". The new libuserd fixture is using this option, and since in the ADO builds we are not passing this option this folder is searched for. For the reasons in point 2., the  installation is not found, and so in the ADO builds we are looking at an install at "/ansys_inc/v{version}/CEI" that does not exist
2. Differently from the PyEnSight installation search, the LibUserd installation search function was not considering the case the Python interpreter is exactly the EnSight Python Interpreter, like in the case of the ADO builds. The ADO builds rely on this search case, so I am adding the same functionality to look for the installation via the enve module