### PR TITLE
add filenotfounderror exception when cleaning the test folder

### DIFF
--- a/src/ansys/pyensight/core/locallauncher.py
+++ b/src/ansys/pyensight/core/locallauncher.py
@@ -314,6 +314,8 @@ class LocalLauncher(Launcher):
                 return
             except PermissionError:
                 pass
+            except FileNotFoundError:
+                pass
             except Exception:
                 raise
         raise RuntimeError(f"Unable to remove {self.session_directory} in {maximum_wait_secs}s")


### PR DESCRIPTION
Vaidy has found an issue while dealing with files downloaded in the session directory, like CFX files, which use locking mechanism.

By the time stop() tries to rmtree the folder, it could record a lock file that then might be removed by the USERD reader closing down. This throws a FileNotFoundException that doesn't change the test result but it is nevertheless reported

So add an additional exception to be "accepted" in the stop function