### PR TITLE
allow numpy > 2 on the PyEnSight side

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "requests>=2.28.2",
     "docker>=6.1.0",
     "urllib3<3.0.0",
-    "numpy>=1.21.0,<2",
+    "numpy>=1.21.0,<3",
     "Pillow>=9.3.0",
     "pypng>=0.0.20",
     "psutil>=5.9.2",


### PR DESCRIPTION
As requested by PyAnsys