### PR TITLE
allow to disable the UI in the remote VNC renderable

### DIFF
--- a/src/ansys/pyensight/core/renderable.py
+++ b/src/ansys/pyensight/core/renderable.py
@@ -606,7 +606,7 @@ class RenderableVNC(Renderable):
                 query_args = f', "extra_query_args":"{optional_query[1:]}"'  # pragma: no cover
 
             attributes = ' renderer="envnc"'
-            attributes += f' ui={ui}'
+            attributes += f" ui={ui}"
             attributes += ' active="true"'
             attributes += (
                 " renderer_options='"

--- a/src/ansys/pyensight/core/renderable.py
+++ b/src/ansys/pyensight/core/renderable.py
@@ -560,6 +560,7 @@ class RenderableVNC(Renderable):
         super().__init__(*args, **kwargs)
         self._generate_url()
         self._rendertype = "remote"
+        self._ui = kwargs.get("ui")
         self.update()
 
     def _update_2023R2_or_less(self):
@@ -585,6 +586,7 @@ class RenderableVNC(Renderable):
         """
         optional_query = self._get_query_parameters_str()
         version = _get_ansysnexus_version(self._session._cei_suffix)
+        ui = "simple" if not self._ui else self._ui
         if int(self._session._cei_suffix) < 242:  # pragma: no cover
             version = ""
             self._update_2023R2_or_less()  # pragma: no cover
@@ -604,7 +606,7 @@ class RenderableVNC(Renderable):
                 query_args = f', "extra_query_args":"{optional_query[1:]}"'  # pragma: no cover
 
             attributes = ' renderer="envnc"'
-            attributes += ' ui="simple"'
+            attributes += f' ui={ui}'
             attributes += ' active="true"'
             attributes += (
                 " renderer_options='"


### PR DESCRIPTION
Right now the remote VNC renderable always uses the "simple" ui option.

I have added a way to change the ui option to an input string the user might give when creating the renderable

I haven't just added an option for "none" because soon we might want a "omniverse" option as well