### PR TITLE
add ui parameter to show command to be passed downstream to VNC renderable

### DIFF
--- a/src/ansys/pyensight/core/renderable.py
+++ b/src/ansys/pyensight/core/renderable.py
@@ -560,6 +560,7 @@ class RenderableVNC(Renderable):
         super().__init__(*args, **kwargs)
         self._generate_url()
         self._rendertype = "remote"
+        self._ui = kwargs.get("ui")
         self.update()
 
     def _update_2023R2_or_less(self):
@@ -585,6 +586,7 @@ class RenderableVNC(Renderable):
         """
         optional_query = self._get_query_parameters_str()
         version = _get_ansysnexus_version(self._session._cei_suffix)
+        ui = "simple" if not self._ui else self._ui
         if int(self._session._cei_suffix) < 242:  # pragma: no cover
             version = ""
             self._update_2023R2_or_less()  # pragma: no cover
@@ -604,7 +606,7 @@ class RenderableVNC(Renderable):
                 query_args = f', "extra_query_args":"{optional_query[1:]}"'  # pragma: no cover
 
             attributes = ' renderer="envnc"'
-            attributes += ' ui="simple"'
+            attributes += f" ui={ui}"
             attributes += ' active="true"'
             attributes += (
                 " renderer_options='"

--- a/src/ansys/pyensight/core/renderable.py
+++ b/src/ansys/pyensight/core/renderable.py
@@ -557,10 +557,13 @@ class RenderableVNC(Renderable):
     """Generates an ansys-nexus-viewer component that can be used to connect to the EnSight VNC remote image renderer."""
 
     def __init__(self, *args, **kwargs) -> None:
+        ui = kwargs.get("ui")
+        if kwargs.get("ui"):
+            kwargs.pop("ui")
         super().__init__(*args, **kwargs)
+        self._ui = ui
         self._generate_url()
         self._rendertype = "remote"
-        self._ui = kwargs.get("ui")
         self.update()
 
     def _update_2023R2_or_less(self):

--- a/src/ansys/pyensight/core/session.py
+++ b/src/ansys/pyensight/core/session.py
@@ -838,6 +838,7 @@ class Session:
         aa: int = 4,
         fps: float = 30.0,
         num_frames: Optional[int] = None,
+        ui: Optional[str] = "simple",
     ) -> "renderable.Renderable":
         """Capture the current EnSight scene or otherwise make it available for
         display in a web browser.
@@ -898,7 +899,7 @@ class Session:
         if self._html_port is None:
             raise RuntimeError("No websocketserver has been associated with this Session")
 
-        kwargs = dict(
+        kwargs: Dict[str, Union[float, int, None, str]] = dict(
             height=height, width=width, temporal=temporal, aa=aa, fps=fps, num_frames=num_frames
         )
         if self._jupyter_notebook:  # pragma: no cover
@@ -924,6 +925,7 @@ class Session:
             else:
                 render = RenderableSGEO(self, **kwargs)
         elif what == "remote":
+            kwargs["ui"] = ui
             render = RenderableVNC(self, **kwargs)
         elif what == "remote_scene":
             render = RenderableEVSN(self, **kwargs)


### PR DESCRIPTION
I created an hook on the RenderableVNC class to change the UI parameter for the ansys-nexus-viewer, but I didn't add it to the show command to be passed downstream. This PR fixes it