### PR TITLE
GLB timeline and material fixes

### DIFF
--- a/src/ansys/pyensight/core/utils/omniverse_glb_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_glb_server.py
@@ -1,4 +1,5 @@
 import io
+import json
 import logging
 import os
 import sys
@@ -108,6 +109,8 @@ class GLBSession(dsg_server.DSGSession):
         part_pb.ambient = 1.0
         part_pb.diffuse = 1.0
         part_pb.specular_intensity = 1.0
+        if "ANSYS_material_details" in mat.extensions:
+            part_pb.material_name = json.dumps(mat.extensions["ANSYS_material_details"])
         # if the material maps to a variable, set the variable id for coloring
         glb_varid = self._find_variable_from_glb_mat(glb_materialid)
         if glb_varid:
@@ -662,8 +665,7 @@ class GLBSession(dsg_server.DSGSession):
         try:
             t0 = self._gltf.scenes[scene_idx].extensions["ANSYS_scene_timevalue"]["timevalue"]
             idx = scene_idx + 1
-            if idx >= num_scenes:
-                idx = scene_idx
+            if idx < num_scenes:
                 t1 = self._gltf.scenes[idx].extensions["ANSYS_scene_timevalue"]["timevalue"]
             else:
                 t1 = t0

--- a/src/ansys/pyensight/core/utils/omniverse_glb_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_glb_server.py
@@ -682,10 +682,13 @@ class GLBSession(dsg_server.DSGSession):
         if timeline[1] - timeline[0] <= 0.0:
             timeline = [0.0, float(num_scenes - 1)]
         # carve time into the input timeline.
-        delta = (timeline[1] - timeline[0]) / float(num_scenes)
+        delta = (timeline[1] - timeline[0]) / float(num_scenes-1)
         output: List[float] = []
         output.append(float(scene_idx) * delta + timeline[0])
-        output.append(output[0] + delta)
+        if scene_idx < num_scenes-1:
+            output.append(output[0] + delta)
+        else:
+            output.append(output[0])
         return output
 
     @staticmethod

--- a/src/ansys/pyensight/core/utils/omniverse_glb_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_glb_server.py
@@ -682,10 +682,10 @@ class GLBSession(dsg_server.DSGSession):
         if timeline[1] - timeline[0] <= 0.0:
             timeline = [0.0, float(num_scenes - 1)]
         # carve time into the input timeline.
-        delta = (timeline[1] - timeline[0]) / float(num_scenes-1)
+        delta = (timeline[1] - timeline[0]) / float(num_scenes - 1)
         output: List[float] = []
         output.append(float(scene_idx) * delta + timeline[0])
-        if scene_idx < num_scenes-1:
+        if scene_idx < num_scenes - 1:
             output.append(output[0] + delta)
         else:
             output.append(output[0])


### PR DESCRIPTION
- The end timepoint for glb file scene timeline was not computed properly. 
- If the GLB material supports the ANSYS material extension, include it in the protobuffer.