### PR TITLE
Handle additional invalid USD names

### DIFF
--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -209,6 +209,11 @@ class OmniverseWrapper(object):
             ord(","): "_",
             ord(" "): "_",
             ord("\\"): "_",
+            ord("^"): "_",
+            ord("!"): "_",
+            ord("#"): "_",
+            ord("%"): "_",
+            ord("&"): "_",
         }
         name = name.translate(replacements)
         if name[0].isdigit():


### PR DESCRIPTION
Extend the replacement table to include "^" and other chars that are not valid in a USD pathname.