### PR TITLE
Temporarily display libuserd tests

### DIFF
--- a/tests/example_tests/test_libuserd.py
+++ b/tests/example_tests/test_libuserd.py
@@ -3,6 +3,7 @@ import numpy
 import pytest
 
 
+@pytest.mark.skip(reason="Temporarily disabled until protobuffer changes complete")
 def test_libuserd_basic(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     use_local = pytestconfig.getoption("use_local_launcher")
@@ -11,9 +12,9 @@ def test_libuserd_basic(tmpdir, pytestconfig: pytest.Config):
     else:
         libuserd = LibUserd(use_docker=True, use_dev=True, data_directory=data_dir)
     libuserd.initialize()
-    libuserd.get_all_readers()
-    libuserd.ansys_release_number()
-    libuserd.ansys_release_string()
+    _ = libuserd.get_all_readers()
+    _ = libuserd.ansys_release_number()
+    _ = libuserd.ansys_release_string()
     cas_file = libuserd.download_pyansys_example("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
     dat_file = libuserd.download_pyansys_example("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
     r = libuserd.query_format(cas_file, dat_file)
@@ -25,14 +26,15 @@ def test_libuserd_basic(tmpdir, pytestconfig: pytest.Config):
     vars = d.variables()
     v = [v for v in vars if v.name == "Static_Pressure"][0]
 
-    p.nodes()
-    p.num_elements()
-    p.element_conn(libuserd.ElementType.HEX08)
-    p.variable_values(v, libuserd.ElementType.HEX08)
+    _ = p.nodes()
+    _ = p.num_elements()
+    _ = p.element_conn(libuserd.ElementType.HEX08)
+    _ = p.variable_values(v, libuserd.ElementType.HEX08)
 
     libuserd.shutdown()
 
 
+@pytest.mark.skip(reason="Temporarily disabled until protobuffer changes complete")
 def test_libuserd_synthetic_time(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     use_local = pytestconfig.getoption("use_local_launcher")

--- a/tests/example_tests/test_libuserd_exhaustive.py
+++ b/tests/example_tests/test_libuserd_exhaustive.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 import numpy as np
+import pytest
 
 ELEMENT_STRING_TO_INT_MAP = {
     "point": 0,
@@ -841,6 +842,7 @@ def compare(userd, session, file1_userd, file2_userd, file1_session, file2_sessi
         )
 
 
+@pytest.mark.skip(reason="Temporarily disabled until protobuffer changes complete")
 def test_cfx(launch_libuserd_and_get_files):
     file_1 = "InjectMixer.res"
     file_2 = None
@@ -860,6 +862,7 @@ def test_cfx(launch_libuserd_and_get_files):
     compare(userd, session, file1_userd, file2_userd, file1_session, file2_session, 0)
 
 
+@pytest.mark.skip(reason="Temporarily disabled until protobuffer changes complete")
 def test_fluent_hdf5(launch_libuserd_and_get_files):
     file_1 = "axial_comp-1-01438.cas.h5"
     file_2 = "axial_comp-1-01438.dat.h5"
@@ -912,6 +915,7 @@ def test_fluent_hdf5(launch_libuserd_and_get_files):
 #    smoke_test(userd, file1_userd, file2_userd)
 
 
+@pytest.mark.skip(reason="Temporarily disabled until protobuffer changes complete")
 def test_ansys_rst(launch_libuserd_and_get_files):
     file_1 = "transient.rst"
     file_2 = None
@@ -930,6 +934,7 @@ def test_ansys_rst(launch_libuserd_and_get_files):
     smoke_test(userd, file1_userd, file2_userd)
 
 
+@pytest.mark.skip(reason="Temporarily disabled until protobuffer changes complete")
 def test_vtk(launch_libuserd_and_get_files):
     file_1 = "rotor_linear_step21_unorm.vtk"
     file_2 = None


### PR DESCRIPTION
In preparation for ADO changes coming in the protobuffer, disable libuserd tests that will start to fail until the transition is complete.