### PR TITLE
add temporary grpcio requirement to fix grpc errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "psutil>=5.9.2",
     "usd-core>=24.8",
     "pygltflib>=1.16.2",
+    "grpcio==1.67.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
It seems that downgrading to 1.67 fixes the issue