### PR TITLE
remove grpcio limitation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
     "pypng>=0.0.20",
     "psutil>=5.9.2",
     "usd-core>=24.8",
-    "pygltflib>=1.16.2",
-    "grpcio>=1.51.1,<1.67.1"
+    "pygltflib>=1.16.2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Given that the gRPC issues seen last week were not related to server and or client gRPC versioning, but they were due to the DSG queue size limit, I am removing the grpcio limitation 