### PR TITLE
add mpi launch for local launcher

### DIFF
--- a/src/ansys/pyensight/core/launcher.py
+++ b/src/ansys/pyensight/core/launcher.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 # keywords.
 INTERCONNECT_MAP = {"ethernet": "eth", "infiniband": "ib"}
 
-MPI_TYPES = ["intel", "intel2018", "openmpi"]
+MPI_TYPES = ["intel", "intel2018", "intel2021", "openmpi"]
 
 
 class Launcher:
@@ -70,8 +70,20 @@ class Launcher:
     launch_web_ui : bool, optional
         Whether to launch the webUI from EnSight
     use_mpi: str, optional
-        If set, EnSight will be launched with the MPI type selected. Valid values
-        are "intel", "intel2018", "openmpi". The remote nodes must be Linux nodes.
+        If set, EnSight will be launched with the MPI type selected. The valid
+        values depend on the EnSight version to be used. The user can see
+        the specific list starting the EnSight Launcher manually and specifying the options
+        to launch EnSight in parallel and MPI. Here are reported the values for releases
+        2024R2 and 2025R1.
+
+        =================== =========================================
+        Release             Valid MPI Types
+        =================== =========================================
+        2024R2              intel2021, intel2018, openmpi
+        2025R1              intel2021, intel2018, openmpi
+        =================== =========================================
+
+        The remote nodes must be Linux nodes.
         This option is valid only if a LocalLauncher is used.
     interconnet: str, optional
         If set, EnSight will be launched with the MPI Interconnect selected. Valid values

--- a/src/ansys/pyensight/core/launcher.py
+++ b/src/ansys/pyensight/core/launcher.py
@@ -34,6 +34,12 @@ if TYPE_CHECKING:
 # See: https://bugs.python.org/issue29288
 "".encode("idna")
 
+# The user doesn't know "eth" and "ib" what they mean. Use more meaningful
+# keywords.
+INTERCONNECT_MAP = {"ethernet": "eth", "infiniband": "ib"}
+
+MPI_TYPES = ["intel", "intel2018", "openmpi"]
+
 
 class Launcher:
     """Provides the EnSight ``Launcher`` base class.
@@ -65,11 +71,11 @@ class Launcher:
         Whether to launch the webUI from EnSight
     use_mpi: str, optional
         If set, EnSight will be launched with the MPI type selected. Valid values
-        are "intel2021", "intel2018", "openmpi". The remote nodes must be Linux nodes.
+        are "intel", "intel2018", "openmpi". The remote nodes must be Linux nodes.
         This option is valid only if a LocalLauncher is used.
     interconnet: str, optional
         If set, EnSight will be launched with the MPI Interconnect selected. Valid values
-        are "ethernet", "infiniband", "myrinet". It requires use_mpi to be set.
+        are "ethernet", "infiniband". It requires use_mpi to be set.
         If use_mpi is set and interconnect is not, "ethernet" will be used.
         This option is valid only if a LocalLauncher is used.
     server_hosts: List[str], optional
@@ -95,17 +101,14 @@ class Launcher:
         self._use_sos = use_sos
         self._use_mpi = use_mpi
         self._interconnect = interconnect
-        if self._use_mpi and self._use_mpi not in ["intel2021", "intel2019", "openmpi"]:
+        if self._use_mpi and self._use_mpi not in MPI_TYPES:
             raise RuntimeError(f"{self._use_mpi} is not a valid MPI option.")
         if self._use_mpi and not self._interconnect:
-            self._interconnect = "eth"
-        if self._interconnect and self._interconnect not in [
-            "eth",
-            "ethernet",
-            "infiniband",
-            "myriniband",
-        ]:
-            raise RuntimeError(f"{self._interconnect} is not a valid MPI interconnect option.")
+            self._interconnect = "ethernet"
+        if self._interconnect:
+            if self._interconnect not in list(INTERCONNECT_MAP.values()):
+                raise RuntimeError(f"{self._interconnect} is not a valid MPI interconnect option.")
+            self._interconnect = INTERCONNECT_MAP.get(self._interconnect)
         self._server_hosts = server_hosts
         if self._use_mpi and not self._server_hosts:
             self._server_hosts = ["localhost"]

--- a/src/ansys/pyensight/core/launcher.py
+++ b/src/ansys/pyensight/core/launcher.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 # keywords.
 INTERCONNECT_MAP = {"ethernet": "eth", "infiniband": "ib"}
 
-MPI_TYPES = ["intel", "intel2018", "intel2021", "openmpi"]
+MPI_TYPES = ["intel2018", "intel2021", "openmpi"]
 
 
 class Launcher:

--- a/src/ansys/pyensight/core/locallauncher.py
+++ b/src/ansys/pyensight/core/locallauncher.py
@@ -218,8 +218,16 @@ class LocalLauncher(Launcher):
                 cmd.append("-egl")
             if self._use_sos:
                 cmd.append("-sos")
-                cmd.append("-nservers")
-                cmd.append(str(int(self._use_sos)))
+                if not self._use_mpi:
+                    cmd.append("-nservers")
+                    cmd.append(str(int(self._use_sos)))
+                else:
+                    cmd.append(f"--np={int(self._use_sos)+1}")
+                    cmd.append(f"--mpi={self._use_mpi}")
+                    cmd.append(f"--ic={self._interconnect}")
+                    hosts = ",".join(self._server_hosts)
+                    cmd.append(f"--cnf={hosts}")
+
             # cmd.append("-minimize_console")
             logging.debug(f"Starting EnSight with : {cmd}\n")
             self._ensight_pid = subprocess.Popen(cmd, **popen_common).pid


### PR DESCRIPTION
For the moment being this workflow is considered only for local launchers.

This is because:

1) I don't think the docker container contains the libraries to run mpi. We might have them on our side, but I am not sure about the system deps
2) The hostnames should be known to the container. This is clearly an IT configuration issue, but I believe we would need proper testing
