### PR TITLE
Workaround random test failures

### DIFF
--- a/tests/example_tests/test_coverage_increase.py
+++ b/tests/example_tests/test_coverage_increase.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import time
 
 from ansys.pyensight.core import DockerLauncher, LocalLauncher, launch_ensight
 from ansys.pyensight.core.enscontext import EnsContext
@@ -298,8 +299,20 @@ def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
     if not use_local:
         launcher.enshell_log_contents()
     assert session.ensight.objs.core.PARTS[0] != session.ensight.objs.core.PARTS[1]
-    cas_file = session.download_pyansys_example("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
-    dat_file = session.download_pyansys_example("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
+    counter = 0
+    while True and counter < 5:
+        try:
+            cas_file = session.download_pyansys_example(
+                "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+            )
+            dat_file = session.download_pyansys_example(
+                "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
+            )
+        except Exception:
+            counter += 1
+            time.sleep(60)
+    if counter == 5:
+        raise RuntimeError("Couldn't download data from github")
     session.load_data(cas_file, result_file=dat_file)
     #
     assert session.ensight_version_check("2021 R1")

--- a/tests/example_tests/test_coverage_increase.py
+++ b/tests/example_tests/test_coverage_increase.py
@@ -300,7 +300,8 @@ def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
         launcher.enshell_log_contents()
     assert session.ensight.objs.core.PARTS[0] != session.ensight.objs.core.PARTS[1]
     counter = 0
-    while True and counter < 5:
+    success = False
+    while not success and counter < 5:
         try:
             cas_file = session.download_pyansys_example(
                 "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
@@ -308,10 +309,11 @@ def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
             dat_file = session.download_pyansys_example(
                 "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
             )
+            success = True
         except Exception:
             counter += 1
             time.sleep(60)
-    if counter == 5:
+    if counter == 5 and not success:
         raise RuntimeError("Couldn't download data from github")
     session.load_data(cas_file, result_file=dat_file)
     #

--- a/tests/example_tests/test_dvs.py
+++ b/tests/example_tests/test_dvs.py
@@ -64,7 +64,8 @@ def test_dvs_data(tmpdir, pytestconfig: pytest.Config):
         launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
     counter = 0
-    while True and counter < 5:
+    success = False
+    while not success and counter < 5:
         try:
             cas_file = session.download_pyansys_example(
                 "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
@@ -72,10 +73,11 @@ def test_dvs_data(tmpdir, pytestconfig: pytest.Config):
             dat_file = session.download_pyansys_example(
                 "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
             )
+            success = True
         except Exception:
             counter += 1
             time.sleep(60)
-    if counter == 5:
+    if counter == 5 and not success:
         raise RuntimeError("Couldn't download data from github")
     session.load_data(cas_file, result_file=dat_file)
     dvs = None

--- a/tests/example_tests/test_dvs.py
+++ b/tests/example_tests/test_dvs.py
@@ -63,8 +63,20 @@ def test_dvs_data(tmpdir, pytestconfig: pytest.Config):
     else:
         launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
-    cas_file = session.download_pyansys_example("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
-    dat_file = session.download_pyansys_example("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
+    counter = 0
+    while True and counter < 5:
+        try:
+            cas_file = session.download_pyansys_example(
+                "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+            )
+            dat_file = session.download_pyansys_example(
+                "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
+            )
+        except Exception:
+            counter += 1
+            time.sleep(60)
+    if counter == 5:
+        raise RuntimeError("Couldn't download data from github")
     session.load_data(cas_file, result_file=dat_file)
     dvs = None
     if use_local:

--- a/tests/example_tests/test_libuserd.py
+++ b/tests/example_tests/test_libuserd.py
@@ -1,4 +1,6 @@
+import glob
 import os
+import time
 
 from ansys.pyensight.core.libuserd import LibUserd
 import numpy
@@ -16,8 +18,20 @@ def test_libuserd_basic(tmpdir, pytestconfig: pytest.Config):
     _ = libuserd.get_all_readers()
     _ = libuserd.ansys_release_number()
     _ = libuserd.ansys_release_string()
-    cas_file = libuserd.download_pyansys_example("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
-    dat_file = libuserd.download_pyansys_example("mixing_elbow.dat.h5", "pyfluent/mixing_elbow")
+    counter = 0
+    while True and counter < 5:
+        try:
+            cas_file = libuserd.download_pyansys_example(
+                "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+            )
+            dat_file = libuserd.download_pyansys_example(
+                "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
+            )
+        except Exception:
+            counter += 1
+            time.sleep(60)
+    if counter == 5:
+        raise RuntimeError("Couldn't download data from github")
     r = libuserd.query_format(cas_file, dat_file)
     d = r[0].read_dataset(cas_file, dat_file)
 
@@ -92,7 +106,12 @@ def test_libuserd_userd_case(tmpdir, pytestconfig: pytest.Config):
     assert len(readers) == 1
     assert readers[0].name == "USERD EnSight Case"
 
-    casedir = libuserd.download_pyansys_example("RC_Plane", "pyensight", folder=True)
+    if use_local:
+        cei_path = os.path.dirname(os.path.dirname(libuserd._server_pathname))
+        suffix = glob.glob(os.path.join(cei_path, "apex???"))[-1][4:]
+        casedir = f"{cei_path}/ensight{suffix}/data/RC_Plane/"
+    else:
+        casedir = libuserd.download_pyansys_example("RC_Plane", "pyensight", folder=True)
     casefile = os.path.join(casedir, "extra300_RC_Plane_nodal.case")
 
     readers = libuserd.query_format(casefile)

--- a/tests/example_tests/test_libuserd.py
+++ b/tests/example_tests/test_libuserd.py
@@ -19,7 +19,8 @@ def test_libuserd_basic(tmpdir, pytestconfig: pytest.Config):
     _ = libuserd.ansys_release_number()
     _ = libuserd.ansys_release_string()
     counter = 0
-    while True and counter < 5:
+    success = False
+    while not success and counter < 5:
         try:
             cas_file = libuserd.download_pyansys_example(
                 "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
@@ -27,10 +28,11 @@ def test_libuserd_basic(tmpdir, pytestconfig: pytest.Config):
             dat_file = libuserd.download_pyansys_example(
                 "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
             )
+            success = True
         except Exception:
             counter += 1
             time.sleep(60)
-    if counter == 5:
+    if counter == 5 and not success:
         raise RuntimeError("Couldn't download data from github")
     r = libuserd.query_format(cas_file, dat_file)
     d = r[0].read_dataset(cas_file, dat_file)


### PR DESCRIPTION
Sometimes there might be network issues fetching data from github, especially if running tests in ADO 

This PR just adds a few workarounds:

1) If possible, use local paths instead of downloading data
2) If the data are not available in a local install, try up to 5 times to download the data, and wait 60 seconds between each try