### PR TITLE
pin grpcio to avoid instabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "pypng>=0.0.20",
     "psutil>=5.9.2",
     "usd-core==24.8",
-    "pygltflib>=1.16.2"
+    "pygltflib>=1.16.2",
+    "grpcio<=1.67.1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
the recent grpcio libraries are unstable when paired with our EnSight install