### PR TITLE
change way webui is launched

### DIFF
--- a/src/ansys/pyensight/core/dockerlauncher.py
+++ b/src/ansys/pyensight/core/dockerlauncher.py
@@ -384,8 +384,7 @@ class DockerLauncher(Launcher):
 
     def launch_webui(self, container_env_str):
         # Run websocketserver
-        cmd = f"cpython /ansys_inc/v{self._ansys_version}/CEI/"
-        cmd += f"nexus{self._ansys_version}/nexus_launcher/webui_launcher.py"
+        cmd = "cpython -m ansys.simba.plugin.post.simba_post"
         # websocket port - this needs to come first since we now have
         # --add_header as a optional arg that can take an arbitrary
         # number of optional headers.

--- a/src/ansys/pyensight/core/locallauncher.py
+++ b/src/ansys/pyensight/core/locallauncher.py
@@ -102,10 +102,8 @@ class LocalLauncher(Launcher):
         """Type of app to launch. Options are ``ensight`` and ``envision``."""
         return self._application
 
-    def launch_webui(self, cpython, webui_script, popen_common):
-        cmd = [cpython]
-        cmd += [webui_script]
-        version = re.findall(r"nexus(\d+)", webui_script)[0]
+    def launch_webui(self, cpython, version, popen_common):
+        cmd = [cpython, "-m", "ansys.simba.plugin.post.simba_post"]
         path_to_webui = self._install_path
         path_to_webui = os.path.join(
             path_to_webui, f"nexus{version}", f"ansys{version}", "ensight", "WebUI", "web", "ui"
@@ -255,7 +253,7 @@ class LocalLauncher(Launcher):
             except Exception:
                 pass
             websocket_script = found_scripts[idx]
-            webui_script = websocket_script.replace("websocketserver.py", "webui_launcher.py")
+            version = re.findall(r"nexus(\d+)", websocket_script)[0]
             # build the commandline
             cmd = [os.path.join(self._install_path, "bin", "cpython"), websocket_script]
             if is_windows:
@@ -307,7 +305,7 @@ class LocalLauncher(Launcher):
         self._sessions.append(session)
 
         if self._launch_webui:
-            self.launch_webui(ensight_python, webui_script, popen_common)
+            self.launch_webui(ensight_python, version, popen_common)
         return session
 
     def stop(self) -> None:

--- a/tests/unit_tests/test_locallauncher.py
+++ b/tests/unit_tests/test_locallauncher.py
@@ -19,20 +19,20 @@ def test_start(mocker):
     mocker.patch.object(LocalLauncher, "_is_system_egl_capable", return_value=False)
     mocker.patch.object(subprocess, "Popen", return_value=popen)
     glob_mock = mock.MagicMock("superGlob")
-    glob_mock.side_effect = ["/path/to/awp/CEI/nexus345/websocketserver.py"]
+    glob_mock.side_effect = [["/path/to/awp/CEI/nexus345/websocketserver.py"]]
     mocker.patch.object(glob, "glob", glob_mock)
     mocker.patch.object(ansys.pyensight.core.session, "Session")
     launcher.start()
-    glob_mock.side_effect = ["/path/to/awp/CEI/nexus345/websocketserver.py"]
+    glob_mock.side_effect = [["/path/to/awp/CEI/nexus345/websocketserver.py"]]
     launcher = LocalLauncher("/path/to/awp/", batch=False)
     launcher.start()
-    glob_mock.side_effect = ["/path/to/awp/CEI/nexus345/websocketserver.py"]
+    glob_mock.side_effect = [["/path/to/awp/CEI/nexus345/websocketserver.py"]]
     launcher = LocalLauncher("/path/to/awp/", use_sos=3)
     launcher.start()
     os.environ["PYENSIGHT_FORCE_ENSIGHT_EGL"] = "1"
     os.environ["ENSIGHT_ANSYS_LAUNCH"] = "1"
     os.environ["PYENSIGHT_DEBUG"] = "1"
-    glob_mock.side_effect = ["/path/to/awp/CEI/nexus345/websocketserver.py"]
+    glob_mock.side_effect = [["/path/to/awp/CEI/nexus345/websocketserver.py"]]
     launcher = LocalLauncher("/path/to/awp/", use_egl=True)
 
 


### PR DESCRIPTION
When the new simba-post PR will be merged, a launcher will be available directly in the module itself.
This will remove the need to update the launcher on the EnSight src, since it comes directly from the simba module

This PR just changes accordingly the launch of simba-post