### PR TITLE
Avoid calling os._exit()

### DIFF
--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -925,7 +925,7 @@ class DSGSession(object):
             except Exception:
                 self._shutdown = True
                 self.log("DSG connection broken, calling exit")
-                os._exit(0)
+                sys.exit(0)
 
     def _get_next_message(self, wait: bool = True) -> Any:
         """Get the next queued up protobuffer message


### PR DESCRIPTION
Calling os._exit() breaks tools like cProfile that rely on clean shutdowns to generate their output.  This change enables:  python -m cProfile -m ansys.pyensight.core.utils.omniverse_cli ...