### PR TITLE
drop support of python 3.9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Installation
 ------------
 To use PyEnSight, you must have a locally installed and licensed copy of
 Ansys EnSight 2022 R2 or later. The ``ansys-pyensight-core`` package supports
-Python 3.9 through Python 3.12 on Windows and Linux.
+Python 3.10 through Python 3.12 on Windows and Linux.
 
 Two modes of installation are available:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "ansys-pyensight-core"
 version = "0.10.0-dev0"
 description = "A python wrapper for Ansys EnSight"
 readme = "README.rst"
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10;,<4"
 license = {file = "LICENSE"}
 authors = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
 maintainers = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
@@ -19,7 +19,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -161,7 +160,7 @@ recursive = true
 exclude = ["venv/*", "tests/*"]
 
 [tool.mypy]
-python_version = 3.9
+python_version = 3.10
 strict = false
 namespace_packages = true
 explicit_package_bases = true


### PR DESCRIPTION
As per pyansys policy, I am dropping the Python 3.9 support
I should add also 3.13, but I cannot yet since usd-core is not there yet