### PR TITLE
avoid error when closing a second session object connected to the same EnSight

### DIFF
--- a/src/ansys/pyensight/core/session.py
+++ b/src/ansys/pyensight/core/session.py
@@ -1058,6 +1058,11 @@ class Session:
                 except RuntimeError:  # pragma: no cover
                     # handle some intermediate EnSight builds.
                     pass
+                except IOError:  # pragma: no cover
+                    # The session might already have been closed via another
+                    # session object. If grpc is inactive, there's no sense
+                    # in raising an exception since we are closing it anyway
+                    pass
             if self._launcher and self._halt_ensight_on_close:
                 self._launcher.close(self)
             else:


### PR DESCRIPTION
Navya reported a bug when when attempting to close a second session object connected to the same ensight instance, where the first session object has been already closed, throws a gRPC error

That's because the close function tries to release the remote python object but the gRPC connection is already closed (together with EnSight).

To avoid the error, I am just catching the IOError exception. Indeed, we are going to close EnSight anyway, so even if this happens on the first session close, it doesn't really matter