### PR TITLE
be explicit on the format to be loaded

### DIFF
--- a/src/ansys/pyensight/core/utils/readers.py
+++ b/src/ansys/pyensight/core/utils/readers.py
@@ -68,6 +68,7 @@ class DVS:
         if monitor_new_timesteps:
             cmd += f'ensight.solution_time.monitor_for_new_steps("{monitor_new_timesteps}")\n'
         cmd += 'ensight.part.elt_representation("3D_feature_2D_full")\n'
+        cmd += 'ensight.data.format("DVS")\n'
         cmd += 'err = ensight.data.replace("notexisting.dvs")\n'
         return cmd
 
@@ -96,6 +97,7 @@ class DVS:
             cmd += f"{indent}dvsfile.write(f'SERVER_SECURITY_SECRET={secret_key}\\n')\n"
         cmd += f'ensight.solution_time.monitor_for_new_steps("{monitor_new_timesteps}")\n'
         cmd += 'ensight.part.elt_representation("3D_feature_2D_full")\n'
+        cmd += 'ensight.data.format("DVS")\n'
         cmd += "ensight.data.replace(path)\n"
         return cmd
 
@@ -154,6 +156,7 @@ class DVS:
                     raise RuntimeError(f"Couldn't write allocated DVS port to {filename}")
             ensight.part.elt_representation("3D_feature_2D_full")
             ensight.solution_time.monitor_for_new_steps(f"{monitor_new_timesteps}")
+            ensight.data.format("DVS")
             ensight.data.replace(path)
         else:
 
@@ -180,6 +183,7 @@ class DVS:
             ensight.objs.core.CURRENTCASE[0].client_command_callback(dvs_callback)
             ensight.solution_time.monitor_for_new_steps(f"{monitor_new_timesteps}")
             ensight.part.elt_representation("3D_feature_2D_full")
+            ensight.data.format("DVS")
             ensight.data.replace("notexisting.dvs")
 
     def launch_live_dvs(


### PR DESCRIPTION
In the past I found an issue in simba-post where starting a DVS live session after a case was loaded was failing

Back in the day I didn't investigate and I considered the issue related to the callback method, thinking that EnSight was trying to call the callback of the previous reader

However, the callback is called AFTER the new reader is started, so EnSight should know on which reader to call the USERD callback stuff

What I found is that the code in PyEnSight launching the DVS server idle was just using "ensight.data.replace".
This works well if no data are loaded because EnSight will find what is the correct reader for that format.
If instead you have a case already loaded and you just use ensight.data.replace, there's missing information about the new reader, and as the name infers, "replace" is just replacing the current case with another one, assuming it is the same reader.

Indeed, a line like "ensight.data.replace("notexisting.dvs")" is giving me in EnSight the error "cannot open CASE file". My first dataset was one of the examples indeed

This makes the fix quite easy. The native API calls I have in place were missing "ensight.data.format("DVS")". With this the callback works well