### PR TITLE
suppress print of error loading numpy 1 compiled module on numpy 2

### DIFF
--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -12,12 +12,19 @@ from ansys.api.pyensight.v0 import dynamic_scene_graph_pb2
 from ansys.pyensight.core import ensight_grpc
 import numpy
 
+original_stderr = sys.stderr
+original_stdout = sys.stdout
+sys.stderr = open(os.devnull, "w")
+sys.stdout = open(os.devnull, "w")
 try:
     import dsgutils
 
     dsgutils_loaded = True
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError, AttributeError):
     dsgutils_loaded = False
+finally:
+    sys.stderr = original_stderr
+    sys.stdout = original_stdout
 
 if TYPE_CHECKING:
     from ansys.pyensight.core import Session

--- a/src/ansys/pyensight/core/utils/omniverse_cli.py
+++ b/src/ansys/pyensight/core/utils/omniverse_cli.py
@@ -5,14 +5,27 @@ import json
 import logging
 import os
 import pathlib
+import sys
 import time
 from typing import Any, List, Optional
 from urllib.parse import urlparse
 
 import ansys.pyensight.core
-import ansys.pyensight.core.utils.dsg_server as dsg_server
-import ansys.pyensight.core.utils.omniverse_dsg_server as ov_dsg_server
-import ansys.pyensight.core.utils.omniverse_glb_server as ov_glb_server
+
+original_stderr = sys.stderr
+original_stdout = sys.stdout
+sys.stderr = open(os.devnull, "w")
+sys.stdout = open(os.devnull, "w")
+try:
+    import ansys.pyensight.core.utils.dsg_server as dsg_server
+    import ansys.pyensight.core.utils.omniverse_dsg_server as ov_dsg_server
+    import ansys.pyensight.core.utils.omniverse_glb_server as ov_glb_server
+except AttributeError as exc:
+    if "_ARRAY_API" not in str(exc):
+        raise exc
+finally:
+    sys.stderr = original_stderr
+    sys.stdout = original_stdout
 
 
 def str2bool_type(v: Any) -> bool:

--- a/src/ansys/pyensight/core/utils/omniverse_glb_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_glb_server.py
@@ -13,7 +13,19 @@ import numpy
 import pygltflib
 
 sys.path.insert(0, os.path.dirname(__file__))
-from dsg_server import UpdateHandler  # noqa: E402
+sys.path.insert(0, os.path.dirname(__file__))
+original_stdout = sys.stdout
+original_stderr = sys.stderr
+sys.stderr = open(os.devnull, "w")
+sys.stdout = open(os.devnull, "w")
+try:
+    from dsg_server import UpdateHandler  # noqa: E402
+except AttributeError as exc:
+    if "_ARRAY_API" not in str(exc):
+        raise exc
+finally:
+    sys.stderr = original_stderr
+    sys.stdout = original_stdout
 
 
 class GLBSession(dsg_server.DSGSession):


### PR DESCRIPTION
dsg_utils is compiler with numpy 1 libraries, while in the PyAnsys environment numpy > 2 might be installed.
Since the current code can go the old route, the eventual error is caught and the print of the error is suppressed

The main issue was that even catching the error this was still printed. So I had to use a more aggressive approach