### PR TITLE
remove extension doc and dynamic_scene_graph internal commands. Propose wait_for_idle example

### DIFF
--- a/doc/source/user_guide/omniverse_info.rst
+++ b/doc/source/user_guide/omniverse_info.rst
@@ -92,8 +92,8 @@ From inside an EnSight session, the API is similar:
 
 Please note, the USD export is asynchronous. Without a proper routine to wait for the
 export to be complete, a script might exit before the export is actually finished.
-The two "monitor_export" routines propose a simple monitoring of the export that uses
-the read_status_file interface, which can read a status file that reports if the
+The two ``monitor_export`` routines propose a simple monitoring of the export that uses
+the ``read_status_file`` interface, which can read a status file that reports if the
 current export is complete or not.
 
 After running the script, the scene will appear in any Omniverse kit tree view
@@ -271,8 +271,12 @@ If the ``--oneshot`` option is not specified, the tool will run in server mode. 
 the DSG protocol or the directory specified by ``--monitor_directory`` option for geometry data.  In
 this mode, the USD scene in the ``destination`` will be updated to reflect the last scene pushed.
 Unused files will be removed and items that do not change will not be updated.  Thus, server
-mode is best suited for dynamic, interactive applications.  If server mode is initiated via the command line,
+mode is best suited for dynamic, interactive applications. If server mode is initiated via the command line,
 a single scene push will automatically be performed.
+If ``--oneshot`` is specified, only a single conversion is performed and the tool will not maintain
+a notion of the scene state.  This makes the operation simpler and avoids the need for extra processes,
+however old files from previous export operations will not be removed and the USD directory may need
+to be manually cleaned between export operations.
 
 
 General Options

--- a/doc/source/user_guide/omniverse_info.rst
+++ b/doc/source/user_guide/omniverse_info.rst
@@ -25,7 +25,8 @@ The API can be used directly from a local Python installation of the
 `ansys-pyensight-core <https://pypi.org/project/ansys-pyensight-core/>`_ module:
 
 .. code-block:: python
-    def wait_for_idle(session):
+
+    def monitor_export(session):
         found = False
         start = time.time()
         while not found and time.time() - start < 60:
@@ -36,17 +37,17 @@ The API can be used directly from a local Python installation of the
         return found
 
     from ansys.pyensight.core import LocalLauncher
-    s = LocalLauncher(batch=False).start()
-    s.load_example("waterbreak.ens")
+    session = LocalLauncher(batch=False).start()
+    session.load_example("waterbreak.ens")
     # The directory to save USD representation into
     usd_directory = "/omniverse/examples/water"
     # Start a new connection between EnSight and Omniverse
-    s.ensight.utils.omniverse.create_connection(usd_directory)
-    wait_for_idle(s)
+    session.ensight.utils.omniverse.create_connection(usd_directory)
+    monitor_export(session)
     # Do some work...
     # Push a scene update
-    s.ensight.utils.omniverse.update()
-    wait_for_idle(s)
+    session.ensight.utils.omniverse.update()
+    monitor_export(session)
 
 
 .. note::
@@ -64,8 +65,7 @@ From inside an EnSight session, the API is similar:
 
 .. code-block:: python
 
-    # Start a DSG server in EnSight first
-    def wait_for_idle():
+    def monitor_export():
         found = False
         start = time.time()
         while not found and time.time() - start < 60:
@@ -75,6 +75,7 @@ From inside an EnSight session, the API is similar:
             time.sleep(0.5)
         return found
 
+    # Start a DSG server in EnSight first
     (_, grpc_port, security) = ensight.objs.core.grpc_server(port=0, start=True)
     # Start a new connection between the EnSight DSG server and Omniverse
     options = {"host": "127.0.0.1", "port": str(grpc_port)}
@@ -82,16 +83,16 @@ From inside an EnSight session, the API is similar:
         options["security"] = security
     usd_directory = "/omniverse/examples/water"
     ensight.utils.omniverse.create_connection(usd_directory, options=options)
-    wait_for_idle()
+    monitor_export()
     # Do some more work...
     # Push a scene update
     ensight.utils.omniverse.update()
-    wait_for_idle()
+    monitor_export()
 
 
 Please note, the USD export is asynchronous. Without a proper routine to wait for the
 export to be complete, a script might exit before the export is actually finished.
-The two "wait_for_idle" routine propose a simple monitoring of the export that uses
+The two "monitor_export" routines propose a simple monitoring of the export that uses
 the read_status_file interface, which can read a status file that reports if the
 current export is complete or not.
 


### PR DESCRIPTION
1. The extension documentation has been removed. I haven't removed yet the UDT tool documentation since it needs to be moved in the EnSight documentation, and also doesn't hurt
2. I have removed the internal commands to ask for a dynamic scene graph update. These are either launched by PyEnSight or by the UDT. The user doesn't need to know about them
3. In the example snippets I have proposed a wait for idle routine to wait for the export to be complete, explaining why