### PR TITLE
Mostieri/disable usdcore linux arm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "Pillow>=9.3.0",
     "pypng>=0.0.20",
     "psutil>=5.9.2",
-    "usd-core==24.8; python_version < '3.13'",
+    "usd-core==24.8; python_version < '3.13' and not (platform_system == 'Linux' and platform_machine == 'aarch64')",
     "pygltflib>=1.16.2"
 ]
 

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -26,6 +26,7 @@
 import logging
 import math
 import os
+import platform
 import shutil
 import sys
 import tempfile
@@ -41,6 +42,10 @@ try:
 except ModuleNotFoundError:
     if sys.version_info.minor >= 13:
         warnings.warn("USD Export not supported for Python >= 3.13")
+        sys.exit(1)
+    is_linux_arm64 = platform.system() == "Linux" and platform.machine() == "aarch64"
+    if is_linux_arm64:
+        warnings.warn("USD Export not supported on Linux ARM platforms")
         sys.exit(1)
 
 


### PR DESCRIPTION
One issue on the integration of simba-post in the simba-app is the possibility of building simba-app on Linux ARM platforms.

While EnSight is not supported on ARM, and this still is an issue, PyEnSight can theoretically be installed on such platforms. However, usd-core is not available yet for arm architectures

So, this PR adds an additional check on the usd-core dependency, not installing it if we are on a linux arm machine. Also, if the user would attempt the DSG export, a warning would be printed

Again, EnSight could still not be used, but at least PyEnSight can be integrated in the simba-app package