### PR TITLE
retrieve downloadable data from local install with option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 Global fixtures go here.
 """
 import atexit
+import os
 import subprocess
 from unittest import mock
 
@@ -23,6 +24,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     """
     parser.addoption("--install-path", action="store")
     parser.addoption("--use-local-launcher", default=False, action="store_true")
+    parser.addoption("--use-local-test-data", default=False, action="store_true")
 
 
 @pytest.fixture
@@ -145,6 +147,7 @@ def launch_libuserd_and_get_files(tmpdir, pytestconfig: pytest.Config):
         data_dir = tmpdir.mkdir("datadir")
         use_local = pytestconfig.getoption("use_local_launcher")
         install_path = pytestconfig.getoption("install_path")
+        use_local_test_data = pytestconfig.getoption("use_local_test_data")
         session = None
         if use_local:
             # Launch locally
@@ -156,24 +159,40 @@ def launch_libuserd_and_get_files(tmpdir, pytestconfig: pytest.Config):
             session = DockerLauncher(use_dev=True, data_directory=data_dir).start()
 
         libuserd.initialize()
+        if not use_local_test_data:
+            count = 0
+            while count < 5:
+                try:
+                    file1_userd = libuserd.download_pyansys_example(filename1, filepath1)
+                    file1_session = session.download_pyansys_example(filename1, filepath1)
 
-        count = 0
-        while count < 5:
-            try:
-                file1_userd = libuserd.download_pyansys_example(filename1, filepath1)
-                file1_session = session.download_pyansys_example(filename1, filepath1)
-
-                if filename2 is None:
-                    file2_userd = ""
-                    file2_session = ""
-                else:
-                    file2_userd = libuserd.download_pyansys_example(filename2, filepath2)
-                    file2_session = session.download_pyansys_example(filename2, filepath2)
-                break
-            except (KeyError, ConnectionError):
-                count += 1
-        if count == 5 and (not file1_userd or not file1_session):
-            raise RuntimeError("Couldn't download files for test.")
+                    if filename2 is None:
+                        file2_userd = ""
+                        file2_session = ""
+                    else:
+                        file2_userd = libuserd.download_pyansys_example(filename2, filepath2)
+                        file2_session = session.download_pyansys_example(filename2, filepath2)
+                    break
+                except (KeyError, ConnectionError):
+                    count += 1
+            if count == 5 and (not file1_userd or not file1_session):
+                raise RuntimeError("Couldn't download files for test.")
+        else:
+            pyensight_test_data_path = os.path.join(
+                session.cei_home,
+                f"apex{session.cei_suffix}",
+                "machines",
+                "common",
+                "PyEnSightTestData",
+            )
+            file1_userd = os.path.join(pyensight_test_data_path, filename1)
+            file1_session = file1_userd
+            if not filename2:
+                file2_userd = ""
+                file2_session = ""
+            else:
+                file2_userd = os.path.join(pyensight_test_data_path, filename2)
+                file2_session = file2_userd
         return file1_userd, file2_userd, file1_session, file2_session, libuserd, session, data_dir
 
     return _files

--- a/tests/example_tests/test_coverage_increase.py
+++ b/tests/example_tests/test_coverage_increase.py
@@ -13,6 +13,7 @@ def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     use_local = pytestconfig.getoption("use_local_launcher")
     install_path = pytestconfig.getoption("install_path")
+    use_local_test_data = pytestconfig.getoption("use_local_test_data")
     root = None
     if use_local:
         launcher = LocalLauncher(ansys_installation=install_path)
@@ -300,22 +301,29 @@ def test_coverage_increase(tmpdir, pytestconfig: pytest.Config):
     if not use_local:
         launcher.enshell_log_contents()
     assert session.ensight.objs.core.PARTS[0] != session.ensight.objs.core.PARTS[1]
-    counter = 0
-    success = False
-    while not success and counter < 5:
-        try:
-            cas_file = session.download_pyansys_example(
-                "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
-            )
-            dat_file = session.download_pyansys_example(
-                "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
-            )
-            success = True
-        except Exception:
-            counter += 1
-            time.sleep(60)
-    if counter == 5 and not success:
-        raise RuntimeError("Couldn't download data from github")
+    if not use_local_test_data:
+        counter = 0
+        success = False
+        while not success and counter < 5:
+            try:
+                cas_file = session.download_pyansys_example(
+                    "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+                )
+                dat_file = session.download_pyansys_example(
+                    "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
+                )
+                success = True
+            except Exception:
+                counter += 1
+                time.sleep(60)
+        if counter == 5 and not success:
+            raise RuntimeError("Couldn't download data from github")
+    else:
+        pyensight_test_data_path = os.path.join(
+            session.cei_home, f"apex{session.cei_suffix}", "machines", "common", "PyEnSightTestData"
+        )
+        cas_file = os.path.join(pyensight_test_data_path, "mixing_elbow.cas.h5")
+        dat_file = os.path.join(pyensight_test_data_path, "mixing_elbow.dat.h5")
     session.load_data(cas_file, result_file=dat_file)
     #
     assert session.ensight_version_check("2021 R1")

--- a/tests/example_tests/test_dvs.py
+++ b/tests/example_tests/test_dvs.py
@@ -59,27 +59,35 @@ def test_dvs_data(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     use_local = pytestconfig.getoption("use_local_launcher")
     install_path = pytestconfig.getoption("install_path")
+    use_local_test_data = pytestconfig.getoption("use_local_test_data")
     if use_local:
         launcher = LocalLauncher(ansys_installation=install_path)
     else:
         launcher = DockerLauncher(data_directory=data_dir, use_dev=True)
     session = launcher.start()
-    counter = 0
-    success = False
-    while not success and counter < 5:
-        try:
-            cas_file = session.download_pyansys_example(
-                "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
-            )
-            dat_file = session.download_pyansys_example(
-                "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
-            )
-            success = True
-        except Exception:
-            counter += 1
-            time.sleep(60)
-    if counter == 5 and not success:
-        raise RuntimeError("Couldn't download data from github")
+    if not use_local_test_data:
+        counter = 0
+        success = False
+        while not success and counter < 5:
+            try:
+                cas_file = session.download_pyansys_example(
+                    "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+                )
+                dat_file = session.download_pyansys_example(
+                    "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
+                )
+                success = True
+            except Exception:
+                counter += 1
+                time.sleep(60)
+        if counter == 5 and not success:
+            raise RuntimeError("Couldn't download data from github")
+    else:
+        pyensight_test_data_path = os.path.join(
+            session.cei_home, f"apex{session.cei_suffix}", "machines", "common", "PyEnSightTestData"
+        )
+        cas_file = os.path.join(pyensight_test_data_path, "mixing_elbow.cas.h5")
+        dat_file = os.path.join(pyensight_test_data_path, "mixing_elbow.dat.h5")
     session.load_data(cas_file, result_file=dat_file)
     dvs = None
     if use_local:

--- a/tests/example_tests/test_libuserd.py
+++ b/tests/example_tests/test_libuserd.py
@@ -10,6 +10,7 @@ import pytest
 def test_libuserd_basic(tmpdir, pytestconfig: pytest.Config):
     data_dir = tmpdir.mkdir("datadir")
     use_local = pytestconfig.getoption("use_local_launcher")
+    use_local_test_data = pytestconfig.getoption("use_local_test_data")
     if use_local:
         libuserd = LibUserd()
     else:
@@ -18,22 +19,33 @@ def test_libuserd_basic(tmpdir, pytestconfig: pytest.Config):
     _ = libuserd.get_all_readers()
     _ = libuserd.ansys_release_number()
     _ = libuserd.ansys_release_string()
-    counter = 0
-    success = False
-    while not success and counter < 5:
-        try:
-            cas_file = libuserd.download_pyansys_example(
-                "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
-            )
-            dat_file = libuserd.download_pyansys_example(
-                "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
-            )
-            success = True
-        except Exception:
-            counter += 1
-            time.sleep(60)
-    if counter == 5 and not success:
-        raise RuntimeError("Couldn't download data from github")
+    if not use_local_test_data:
+        counter = 0
+        success = False
+        while not success and counter < 5:
+            try:
+                cas_file = libuserd.download_pyansys_example(
+                    "mixing_elbow.cas.h5", "pyfluent/mixing_elbow"
+                )
+                dat_file = libuserd.download_pyansys_example(
+                    "mixing_elbow.dat.h5", "pyfluent/mixing_elbow"
+                )
+                success = True
+            except Exception:
+                counter += 1
+                time.sleep(60)
+        if counter == 5 and not success:
+            raise RuntimeError("Couldn't download data from github")
+    else:
+        pyensight_test_data_path = os.path.join(
+            libuserd._cei_home,
+            f"apex{libuserd.ansys_release_number}",
+            "machines",
+            "common",
+            "PyEnSightTestData",
+        )
+        cas_file = os.path.join(pyensight_test_data_path, "mixing_elbow.cas.h5")
+        dat_file = os.path.join(pyensight_test_data_path, "mixing_elbow.dat.h5")
     r = libuserd.query_format(cas_file, dat_file)
     d = r[0].read_dataset(cas_file, dat_file)
 


### PR DESCRIPTION
Running tests on ADO is resulting in several issues downloading data from github
So, add a path to get the data from the local (dev) install. The data have been packed as a tgz available in the sync location