### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "pypng>=0.0.20",
     "psutil>=5.9.2",
     "usd-core==24.8; python_version < '3.13' and platform_machine != 'aarch64'",
-    "pygltflib>=1.16.2"
+    "pygltflib>=1.16.2",
+    "grpcio<1.68.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
PyEnSight is affected by the grpcio bug https://github.com/grpc/grpc/issues/38282. This bug started from grpcio 1.68.0 and hasn't been fixed yet

Because of this issue, the connection to EnSight is unstable, often disconnecting abruptly