### PR TITLE
Set USD scene up direction

### DIFF
--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -767,7 +767,7 @@ class OmniverseUpdateHandler(UpdateHandler):
                     sc = Gf.Matrix4d(self._omni._units_per_meter)
                     cam.transform = c * m.GetInverse() * sc
 
-                    # Determine if the camera is prinicipally more Y, or Z up.  X up not supported.
+                    # Determine if the camera is principally more Y, or Z up.  X up not supported.
                     # Omniverse' built in navigator tries to keep this direction up
                     # If the view is principally -Y, there is no good choice.  +Y is least bad.
                     cam_upvec = Gf.Vec4d(0, 1, 0, 0) * cam.transform

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -70,7 +70,7 @@ class OmniverseWrapper(object):
         self._time_codes_per_second: float = 120.0
         # Omniverse content currently only scales correctly for scenes in cm.  DJB, Feb 2025
         self._units_per_meter: float = 100.0
-
+        self._up_axis: str = UsdGeom.Tokens.y
         if destination:
             self.destination = destination
 
@@ -163,7 +163,7 @@ class OmniverseWrapper(object):
         self._stage = Usd.Stage.CreateNew(self.stage_url())
         # record the stage in the "_old_stages" list.
         self._old_stages.append(self.stage_url())
-        UsdGeom.SetStageUpAxis(self._stage, UsdGeom.Tokens.y)
+        UsdGeom.SetStageUpAxis(self._stage, self._up_axis)
         UsdGeom.SetStageMetersPerUnit(self._stage, 1.0 / self._units_per_meter)
         logging.info(f"Created stage: {self.stage_url()}")
 
@@ -302,7 +302,7 @@ class OmniverseWrapper(object):
 
         if not os.path.exists(part_stage_url):
             part_stage = Usd.Stage.CreateNew(part_stage_url)
-            UsdGeom.SetStageUpAxis(part_stage, UsdGeom.Tokens.y)
+            UsdGeom.SetStageUpAxis(part_stage, self._up_axis)
             UsdGeom.SetStageMetersPerUnit(part_stage, 1.0 / self._units_per_meter)
             self._old_stages.append(part_stage_url)
             xform = UsdGeom.Xform.Define(part_stage, "/" + partname)
@@ -400,7 +400,7 @@ class OmniverseWrapper(object):
 
         if not os.path.exists(part_stage_url):
             part_stage = Usd.Stage.CreateNew(part_stage_url)
-            UsdGeom.SetStageUpAxis(part_stage, UsdGeom.Tokens.y)
+            UsdGeom.SetStageUpAxis(part_stage, self._up_axis)
             UsdGeom.SetStageMetersPerUnit(part_stage, 1.0 / self._units_per_meter)
             self._old_stages.append(part_stage_url)
             xform = UsdGeom.Xform.Define(part_stage, "/" + partname)
@@ -485,7 +485,7 @@ class OmniverseWrapper(object):
 
         if not os.path.exists(part_stage_url):
             part_stage = Usd.Stage.CreateNew(part_stage_url)
-            UsdGeom.SetStageUpAxis(part_stage, UsdGeom.Tokens.y)
+            UsdGeom.SetStageUpAxis(part_stage, self._up_axis)
             UsdGeom.SetStageMetersPerUnit(part_stage, 1.0 / self._units_per_meter)
             self._old_stages.append(part_stage_url)
             xform = UsdGeom.Xform.Define(part_stage, "/" + partname)
@@ -766,6 +766,17 @@ class OmniverseUpdateHandler(UpdateHandler):
                     # move the model transform to the camera transform
                     sc = Gf.Matrix4d(self._omni._units_per_meter)
                     cam.transform = c * m.GetInverse() * sc
+
+                    # Determine if the camera is prinicipally more Y, or Z up.  X up not supported.
+                    # Omniverse' built in navigator tries to keep this direction up
+                    # If the view is principally -Y, there is no good choice.  +Y is least bad.
+                    cam_upvec = Gf.Vec4d(0, 1, 0, 0) * cam.transform
+                    if abs(cam_upvec[1]) >= abs(cam_upvec[2]):
+                        self._up_axis = UsdGeom.Tokens.y
+                    else:
+                        self._up_axis = UsdGeom.Tokens.z
+                    UsdGeom.SetStageUpAxis(self._omni._stage, self._up_axis)
+
                     # set the updated camera
                     geom_cam.SetFromCamera(cam)
                     # apply the inverse cam transform to move the center of interest


### PR DESCRIPTION
Based on the camera matrix, set the USD scene's up direction.  This helps the built in Omniverse navigator work better.