### PR TITLE
Export transient USD files using value clips

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,18 +21,6 @@ repos:
         additional_dependencies: ["tomli"]
         args: ["--ignore-words", "doc/styles/config/vocabularies/ANSYS/accept.txt"]
 
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
-    hooks:
-      - id: bandit
-        # args not working with pyproject.toml
-        args: [
-            -lll,
-            -n, "3",
-            -r,
-            -x, "venv/*, tests/*"
-        ]
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.3.0
     hooks:

--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -57,7 +57,6 @@ class Part(object):
         self.cmd: Optional[Any] = None
         self.hash = hashlib.new("sha256")
         self._material: Optional[Any] = None
-        self._time_files: Optional[list] = []
         self.reset()
 
     def reset(self, cmd: Any = None) -> None:

--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -57,6 +57,7 @@ class Part(object):
         self.cmd: Optional[Any] = None
         self.hash = hashlib.new("sha256")
         self._material: Optional[Any] = None
+        self._time_files: Optional[list] = []
         self.reset()
 
     def reset(self, cmd: Any = None) -> None:

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -26,12 +26,10 @@
 import logging
 import math
 import os
-from pickle import NONE
 import platform
 import shutil
 import sys
 import tempfile
-from types import NoneType
 from typing import Any, Dict, List, Optional
 import warnings
 
@@ -40,7 +38,7 @@ import numpy
 import png
 
 try:
-    from pxr import Gf, Kind, Sdf, Usd, UsdGeom, UsdLux, UsdShade, Vt
+    from pxr import Gf, Sdf, Usd, UsdGeom, UsdLux, UsdShade
 except ModuleNotFoundError:
     if sys.version_info.minor >= 13:
         warnings.warn("USD Export not supported for Python >= 3.13")
@@ -80,7 +78,7 @@ class OmniverseWrapper(object):
 
         self._line_width = line_width
         # Record the files per timestep, per mesh type.  {part_name: {"surfaces": [], "lines": [], "points": []} }
-        self._time_files = dict()
+        self._time_files: dict = {}
 
     @property
     def destination(self) -> str:
@@ -286,15 +284,15 @@ class OmniverseWrapper(object):
     # Common code to create the part manifest file and the file per timestep
     def create_dsg_surfaces_file(
         self,
-        file_url: any,  # SdfPath, location on disk
+        file_url,  # SdfPath, location on disk
         part_path: str,  # base path name, such as "/Root/Case_1/Isosurface_part"
-        verts: any,
-        normals: any,
-        conn: any,
-        tcoords: any,
-        diffuse: any,
-        variable: any,
-        mat_info: any,
+        verts,
+        normals,
+        conn,
+        tcoords,
+        diffuse,
+        variable,
+        mat_info,
         is_manifest: bool,
     ):
         if is_manifest and file_url in self._old_stages:
@@ -310,9 +308,7 @@ class OmniverseWrapper(object):
         part_prim = stage.OverridePrim(part_path)
 
         surfaces_prim = UsdGeom.Xform.Define(stage, part_path + "/surfaces")
-        matrixOp = surfaces_prim.AddXformOp(
-            UsdGeom.XformOp.TypeTransform, UsdGeom.XformOp.PrecisionDouble
-        )
+        surfaces_prim.AddXformOp(UsdGeom.XformOp.TypeTransform, UsdGeom.XformOp.PrecisionDouble)
         mesh = UsdGeom.Mesh.Define(stage, str(surfaces_prim.GetPath()) + "/Mesh")
         mesh.CreateDoubleSidedAttr().Set(True)
         pt_attr = mesh.CreatePointsAttr()
@@ -369,6 +365,9 @@ class OmniverseWrapper(object):
         first_timestep=False,
         mat_info={},
     ):
+        if self._stage is None:
+            return
+
         # 1D texture map for variables https://graphics.pixar.com/usd/release/tut_simple_shading.html
         # create the part usd object
         part_base_name = self.clean_name(name)
@@ -462,14 +461,14 @@ class OmniverseWrapper(object):
     # Common code to create the part manifest file and the file per timestep
     def create_dsg_lines_file(
         self,
-        file_url: any,  # SdfPath, location on disk
+        file_url,  # SdfPath, location on disk
         part_path: str,  # base path name, such as "/Root/Case_1/Isosurface_part"
-        verts: any,
+        verts,
         width: float,
-        tcoords: any,
-        diffuse: any,
-        var_cmd: any,
-        mat_info: any,
+        tcoords,
+        diffuse,
+        var_cmd,
+        mat_info,
         is_manifest: bool,
     ):
         if is_manifest and file_url in self._old_stages:
@@ -486,9 +485,7 @@ class OmniverseWrapper(object):
 
         lines_prim = UsdGeom.Xform.Define(stage, part_path + "/lines")
 
-        matrixOp = lines_prim.AddXformOp(
-            UsdGeom.XformOp.TypeTransform, UsdGeom.XformOp.PrecisionDouble
-        )
+        lines_prim.AddXformOp(UsdGeom.XformOp.TypeTransform, UsdGeom.XformOp.PrecisionDouble)
         lines = UsdGeom.BasisCurves.Define(stage, str(lines_prim.GetPath()) + "/Lines")
         lines.CreateDoubleSidedAttr().Set(True)
         pt_attr = lines.CreatePointsAttr()
@@ -603,13 +600,13 @@ class OmniverseWrapper(object):
     # Common code to create the part manifest file and the file per timestep
     def create_dsg_points_file(
         self,
-        file_url: any,  # SdfPath, location on disk
+        file_url,  # SdfPath, location on disk
         part_path: str,  # base path name, such as "/Root/Case_1/Isosurface_part"
-        verts: any,
-        sizes: any,
-        colors: any,
+        verts,
+        sizes,
+        colors,
         default_size: float,
-        default_color: any,
+        default_color,
         is_manifest: bool,
     ):
         if is_manifest and file_url in self._old_stages:

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -304,7 +304,7 @@ class OmniverseWrapper(object):
             return False
 
         stage = Usd.Stage.CreateNew(file_url)
-        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+        UsdGeom.SetStageUpAxis(stage, self._up_axis)
         UsdGeom.SetStageMetersPerUnit(stage, 1.0 / self._units_per_meter)
         self._old_stages.append(file_url)
 
@@ -434,7 +434,7 @@ class OmniverseWrapper(object):
             return False
 
         stage = Usd.Stage.CreateNew(file_url)
-        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+        UsdGeom.SetStageUpAxis(stage, self._up_axis)
         UsdGeom.SetStageMetersPerUnit(stage, 1.0 / self._units_per_meter)
         self._old_stages.append(file_url)
 
@@ -546,7 +546,7 @@ class OmniverseWrapper(object):
             return False
 
         stage = Usd.Stage.CreateNew(file_url)
-        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+        UsdGeom.SetStageUpAxis(stage, self._up_axis)
         UsdGeom.SetStageMetersPerUnit(stage, 1.0 / self._units_per_meter)
         self._old_stages.append(file_url)
 

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -353,10 +353,21 @@ class OmniverseWrapper(object):
             mesh = UsdGeom.Mesh.Define(part_stage, "/Root/Case_1/" + part_base_name + "/Mesh")
             # mesh.CreateDisplayColorAttr()
             mesh.CreateDoubleSidedAttr().Set(True)
-            mesh.CreatePointsAttr(verts)
-            mesh.CreateNormalsAttr(normals)
-            mesh.CreateFaceVertexCountsAttr([3] * (conn.size // 3))
-            mesh.CreateFaceVertexIndicesAttr(conn)
+
+            #mesh.CreatePointsAttr(verts)
+            #mesh.CreateNormalsAttr(normals)
+            #mesh.CreateFaceVertexCountsAttr([3] * (conn.size // 3))
+            #mesh.CreateFaceVertexIndicesAttr(conn)
+
+            pt_attr = mesh.CreatePointsAttr()
+            pt_attr.Set(verts, 0)
+            norm_attr = mesh.CreateNormalsAttr()
+            norm_attr.Set(normals, 0)
+            fvc_attr = mesh.CreateFaceVertexCountsAttr()
+            fvc_attr.Set([3] * (conn.size // 3), 0)
+            fvi_attr = mesh.CreateFaceVertexIndicesAttr()
+            fvi_attr.Set(conn, 0)
+
             if (tcoords is not None) and variable:
                 primvarsAPI = UsdGeom.PrimvarsAPI(mesh)
                 texCoords = primvarsAPI.CreatePrimvar(
@@ -366,6 +377,13 @@ class OmniverseWrapper(object):
                 texCoords.SetInterpolation("vertex")
             part_prim = part_stage.GetPrimAtPath("/Root/Case_1/" + part_base_name)
             part_stage.SetDefaultPrim(part_prim)
+            #part_stage.SetStartTimeCode(int(timeline[0]))
+            #part_stage.SetEndTimeCode(int(timeline[1]))
+            part_stage.SetStartTimeCode(0)
+            part_stage.SetEndTimeCode(0)
+
+            self._stage.SetStartTimeCode(0)
+            self._stage.SetEndTimeCode(int(timeline[1]))
 
             # Currently, this will never happen, but it is a setup for rigid body transforms
             # At present, the group transforms have been cooked into the vertices so this is not needed
@@ -417,7 +435,7 @@ class OmniverseWrapper(object):
             part._time_files.append((asset_path, timeline[0]))
             clips_api.SetClipAssetPaths( [time_file[0] for time_file in part._time_files] )
             clips_api.SetClipActive( [ (time_file[1], ii) for ii, time_file in enumerate(part._time_files) ] )
-            clips_api.SetClipTimes( [ (time_file[1], time_file[1]) for ii, time_file in enumerate(part._time_files) ] )
+            clips_api.SetClipTimes( [ (time_file[1], 0) for ii, time_file in enumerate(part._time_files) ] )
             clips_api.SetClipPrimPath("/Root/Case_1/Isosurface_part")
             #clips_api.SetClipManifestAssetPath(Sdf.AssetPath("./Parts/Isosurface_part_manifest.usda"))
             clips_api.SetClipManifestAssetPath(Sdf.AssetPath("./Isosurface_part_manifest.usda"))


### PR DESCRIPTION
Value clips are a different, better supported way of implementing transient USD files.  The new root file has a list of files that describe each part at various timesteps.  Parts with identical hashes will still only be written once, and the timeline over which it is used is extended.

In addition, a manifest file is created for each part, which contains the same part hierarchy, without the payload.  The code to create the file is broken out into create_dsg_surfaces_file(), create_dsg_lines_file(), and create_dsg_points_file(), so it can be called twice, with and without the payload.

The USD exporter will no longer work with EnSight 25.2, unless the files are small.  It cannot handle multiple chunks of 2M tris, for a part at a timestep.