### PR TITLE
Search the local build area for the launch script.

### DIFF
--- a/src/ansys/pyensight/core/utils/omniverse.py
+++ b/src/ansys/pyensight/core/utils/omniverse.py
@@ -272,7 +272,17 @@ def find_app(ansys_installation: Optional[str] = None) -> Optional[str]:
         if os.path.exists(local_tp):
             dirs_to_check.append(local_tp)
         # Dev Folder
-        local_dev_omni = os.path.join(ansys_installation, "omni_build")
+        omni_platform_dir = "linux-x86_64"
+        if sys.platform.startswith("win"):
+            omni_platform_dir = "windows-x86_64"
+        local_dev_omni = os.path.join(
+            ansys_installation,
+            "omni_build",
+            "kit-app-template",
+            "_build",
+            omni_platform_dir,
+            "release",
+        )
         if os.path.exists(local_dev_omni):
             dirs_to_check.append(local_dev_omni)
     if "PYENSIGHT_ANSYS_INSTALLATION" in os.environ:


### PR DESCRIPTION
When running the omniverse app from a local install, search in [CEI source root]/omni_build/kit-app-template/_build/[platform]/release.

The EnSight branch djbremer/omni_app_rest has a build script change, to copy the launch scripts to the build area, during a 'make viewer'.  This PR, combined with the change in djbremer/omni_app_rest, will allow pyensight to launch a local Omniverse build using:

from ansys.pyensight.core.utils import omniverse
ov2 = omniverse.launch_app(ansys_installation="[CEI source root]")