### PR TITLE
Faster launcher stop

### DIFF
--- a/src/ansys/pyensight/core/dockerlauncher.py
+++ b/src/ansys/pyensight/core/dockerlauncher.py
@@ -1033,15 +1033,23 @@ class DockerLauncher(Launcher):
         #
         if self._container:
             try:
-                logging.debug("Stopping the Docker Container.\n")
-                self._container.stop()
+                logging.debug("Stopping the Docker Container (graceful, timeout=5).\n")
+                try:
+                    # try a short graceful stop
+                    self._container.stop(timeout=5)
+                except Exception:
+                    try:
+                        logging.debug("Graceful stop failed, killing container.\n")
+                        self._container.kill()
+                    except Exception:
+                        logging.debug("Container kill failed.\n")
             except Exception:
-                pass
+                logging.debug("Error while stopping/killing container.\n")
             try:
                 logging.debug("Removing the Docker Container.\n")
                 self._container.remove(force=True)
             except Exception:
-                pass
+                logging.debug("Error removing container.\n")
             self._container = None
 
         if self._pim_instance is not None:

--- a/src/ansys/pyensight/core/locallauncher.py
+++ b/src/ansys/pyensight/core/locallauncher.py
@@ -38,6 +38,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 from typing import Optional
 import uuid
@@ -462,21 +463,46 @@ class LocalLauncher(Launcher):
 
     def stop(self) -> None:
         """Release any additional resources allocated during launching."""
-        maximum_wait_secs = 120.0
-        start_time = time.time()
-        while (time.time() - start_time) < maximum_wait_secs:
-            try:
-                shutil.rmtree(self.session_directory)
-                self._ports = None
-                super().stop()
-                return
-            except PermissionError:
-                pass
-            except FileNotFoundError:
-                pass
-            except Exception:
-                raise
-        raise RuntimeError(f"Unable to remove {self.session_directory} in {maximum_wait_secs}s")
+
+        # Perform directory removal asynchronously to avoid blocking callers.
+        def _remove_session_dir(path: str) -> None:
+            maximum_wait_secs = 120.0
+            start_time = time.time()
+            while (time.time() - start_time) < maximum_wait_secs:
+                try:
+                    shutil.rmtree(path)
+                    return
+                except PermissionError:
+                    # likely files still held open; retry briefly
+                    time.sleep(0.5)
+                except FileNotFoundError:
+                    return
+                except Exception:
+                    return
+
+        try:
+            t = threading.Thread(
+                target=_remove_session_dir, args=(self.session_directory,), daemon=True
+            )
+            t.start()
+        except Exception:
+            # If threading fails for any reason, fall back to synchronous removal
+            maximum_wait_secs = 120.0
+            start_time = time.time()
+            while (time.time() - start_time) < maximum_wait_secs:
+                try:
+                    shutil.rmtree(self.session_directory)
+                    break
+                except PermissionError:
+                    time.sleep(0.5)
+                except FileNotFoundError:
+                    break
+                except Exception:
+                    break
+
+        # Clear port allocation and let base class perform any remaining cleanup.
+        self._ports = None
+        super().stop()
 
     def close(self, session):
         """Shut down the launched EnSight session.


### PR DESCRIPTION
The current stop methods for the docker launcher and the local launcher are way too slow

For the first one, only graceful methods are being used, that could take too much time. A graceful attempt is now done, with a short timeout. If it doesn't work, the container is just killed

For the local launcher, the main issue is the directory removal. This takes a lot of times and in many cases is just left behind. Being a temp folder, it can be kept where it is if the folder removal doesn't make in time. This is now moved to a specific thread that doesn't block 