### PR TITLE
feat: Improve status reporting for transient USD export

### DIFF
--- a/doc/source/user_guide/omniverse_info.rst
+++ b/doc/source/user_guide/omniverse_info.rst
@@ -31,7 +31,7 @@ The API can be used directly from a local Python installation of the
         start = time.time()
         while not found and time.time() - start < 60:
             status = session.ensight.utils.omniverse.read_status_file()
-            if status.get("status") == "idle":
+            if status.get("status") == "complete":
                 found = True
             time.sleep(0.5)
         return found
@@ -70,7 +70,7 @@ From inside an EnSight session, the API is similar:
         start = time.time()
         while not found and time.time() - start < 60:
             status = ensight.utils.omniverse.read_status_file()
-            if status.get("status") == "idle":
+            if status.get("status") == "complete":
                 found = True
             time.sleep(0.5)
         return found

--- a/exts/ansys.tools.omniverse.dsgui/ansys/tools/omniverse/dsgui/extension.py
+++ b/exts/ansys.tools.omniverse.dsgui/ansys/tools/omniverse/dsgui/extension.py
@@ -113,8 +113,9 @@ class AnsysToolsOmniverseDSGUIExtension(omni.ext.IExt):
         else:
             self._connect_w.text = "Connect to DSG Server"
             self._label_w.text = "No connected DSG server" + self._error_msg
-        self._update_w.enabled = self._connected and (status.get("status", "idle") == "idle")
-        self._connect_w.enabled = status.get("status", "idle") == "idle"
+        st = status.get("status", "idle")
+        self._update_w.enabled = self._connected and (st == "idle" or st == "complete")
+        self._connect_w.enabled = st == "idle" or st == "complete"
         self._temporal_w.enabled = True
         self._vrmode_w.enabled = not self._connected
         self._normalize_w.enabled = not self._connected

--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -942,10 +942,12 @@ class DSGSession(object):
         following json object, stored as: self._status
 
         {
-        'status' : "working|idle",
+        'status' : "idle|working|complete",
         'start_time' : timestamp_of_update_begin,
         'processed_buffers' : number_of_protobuffers_processed,
         'total_buffers' : number_of_protobuffers_total,
+        'timestep' : timestep/flipbook page currently being process, if transient
+        'num_timesteps' : total number of timesteps/flipbook pages, if transient
         }
 
         Parameters

--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -1072,6 +1072,13 @@ class DSGSession(object):
             cmd.command_type != dynamic_scene_graph_pb2.SceneUpdateCommand.UPDATE_SCENE_END
         ):
             self._handle_update_command(cmd)
+
+            if cmd.command_type == dynamic_scene_graph_pb2.SceneUpdateCommand.UPDATE_VIEW:
+                if hasattr(cmd.update_view, "num_timesteps") and cmd.update_view.num_timesteps > 0:
+                    # Older protocol is missing num_timesteps, so it will be 0
+                    self._status["timestep"] = cmd.update_view.timestep  # type: ignore
+                    self._status["num_timesteps"] = cmd.update_view.num_timesteps  # type: ignore
+
             self._status["processed_buffers"] += 1  # type: ignore
             self._status["total_buffers"] = self._status["processed_buffers"] + self._message_queue.qsize()  # type: ignore
             self._update_status_file(timed=True)
@@ -1083,7 +1090,7 @@ class DSGSession(object):
         self._callback_handler.end_update()
 
         # Update our status
-        self._status = dict(status="idle", start_time=0.0, processed_buffers=0, total_buffers=0)
+        self._status = dict(status="complete", start_time=0.0, processed_buffers=0, total_buffers=0)
         self._update_status_file()
 
     def _handle_update_command(self, cmd: dynamic_scene_graph_pb2.SceneUpdateCommand) -> None:

--- a/src/ansys/pyensight/core/utils/omniverse.py
+++ b/src/ansys/pyensight/core/utils/omniverse.py
@@ -70,6 +70,7 @@ class OmniverseKitInstance:
         )
         self._scanner_thread.start()
         self._simba_url: Optional[ParseResult] = None
+        self._exit_messages: Optional[dict] = None
 
     def __del__(self) -> None:
         """Close down the instance on delete"""
@@ -148,6 +149,24 @@ class OmniverseKitInstance:
         """
         return self._simba_url
 
+    def launch_progress(self) -> float:
+        """Return the progress toward launching, in [0, 1]
+
+        Returns
+        -------
+        float
+            1 means it is rendering and the simba server is running, or it has started and exited.
+            [0, .99] is based on a count of the number of lines of output / total lines of output
+        """
+        approx_output_lines = 500
+        if self.returncode() is not None:
+            # Process is no longer running
+            return 1
+        elif self.is_rendering() and self.simba_url() is not None:
+            return 1
+        else:
+            return 0.99 * (min(self._lines_read, approx_output_lines) / approx_output_lines)
+
     def returncode(self) -> Optional[int]:
         """Get the return code if the process has stopped, or None if still running
 
@@ -162,6 +181,9 @@ class OmniverseKitInstance:
             return None
         self._returncode = self._proc.returncode
         return self._returncode
+
+    def exit_messages(self) -> Optional[dict]:
+        return self._exit_messages
 
 
 # Deprecated
@@ -345,11 +367,37 @@ def find_app(ansys_installation: Optional[str] = None) -> Optional[str]:
     return None
 
 
+def get_app_exit_messages(app_file: str) -> Optional[dict]:
+    """
+    Load the Omniverse python launch script as a module.
+    Return the attribute EXIT_MESSAGES that maps
+    launch script exit codes to human readable explanations.
+    """
+    try:
+        import importlib.util
+
+        module_name = "ansys_tools_omni_core"
+        spec = importlib.util.spec_from_file_location(module_name, app_file)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        exit_msgs = getattr(module, "EXIT_MESSAGES", None)
+        if isinstance(exit_msgs, dict):
+            return exit_msgs
+    except (ImportError, ModuleNotFoundError, AttributeError, SyntaxError, FileNotFoundError):
+        pass
+    # Older builds of the Omniverse launcher do not have the EXIT_MESSAGES attr
+    return None
+
+
 def launch_app(
     usd_file: Optional[str] = "",
     layout: Optional[str] = "default",
     streaming: Optional[bool] = False,
     offscreen: Optional[bool] = False,
+    dry_run: Optional[bool] = False,
     log_file: Optional[str] = None,
     log_level: Optional[str] = "warn",
     cli_options: Optional[List[str]] = None,
@@ -368,6 +416,8 @@ def launch_app(
     #    Enable webrtc streaming to enable the window in a web page
     # offscreen : Optional[str]
     #    Run the app offscreen.  Useful when streaming.
+    # dry_run : Optional[str]
+    #    Do only the validation checks.  Examine the return code to learn whether the app could run.
     # log_file : Optional[str]
     #    The name of a text file where the logging information for the instance will be saved.
     # log_level : Optional[str]
@@ -395,6 +445,12 @@ def launch_app(
     app = find_app(ansys_installation=ansys_installation)
     if not app:
         raise RuntimeError("Unable to find the Ansys Omniverse app")
+    exit_msgs = get_app_exit_messages(app)
+    if dry_run and exit_msgs is None:
+        raise RuntimeError(
+            "The installed Ansys Omniverse app is too old to support dry-run mode.  Please update to a newer version."
+        )
+
     cmd.extend([app])
     if usd_file:
         cmd.extend(["-f", usd_file])
@@ -404,6 +460,8 @@ def launch_app(
         cmd.extend(["-s"])
     if offscreen:
         cmd.extend(["-o"])
+    if dry_run:
+        cmd.extend(["--dry-run"])
     if cli_options:
         cmd.extend(cli_options)
     if log_level:
@@ -416,7 +474,11 @@ def launch_app(
     # Launch the process
     env_vars = os.environ.copy()
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env_vars)
-    return OmniverseKitInstance(p)
+
+    omni_kit = OmniverseKitInstance(p)
+    omni_kit._exit_messages = exit_msgs
+
+    return omni_kit
 
 
 class Omniverse:

--- a/tests/example_tests/test_usd_export.py
+++ b/tests/example_tests/test_usd_export.py
@@ -58,12 +58,12 @@ def compare_usd_files(stage1, stage2):
     return True
 
 
-def wait_for_idle(session):
+def wait_for_complete(session):
     found = False
     start = time.time()
     while not found and time.time() - start < 60:
         status = session.ensight.utils.omniverse.read_status_file()
-        if status.get("status") == "idle":
+        if status.get("status") == "complete":
             found = True
         time.sleep(0.5)
     return found
@@ -85,7 +85,7 @@ def test_usd_export(tmpdir, pytestconfig: pytest.Config):
     session = launcher.start()
     session.load_example("waterbreak.ens")
     session.ensight.utils.omniverse.create_connection(data_dir)
-    assert wait_for_idle(session)
+    assert wait_for_complete(session)
     usd_files = glob.glob(os.path.join(data_dir, "*.usd"))
     assert len(usd_files) == 1
     base_usd = usd_files[0]
@@ -100,14 +100,14 @@ def test_usd_export(tmpdir, pytestconfig: pytest.Config):
     stage1 = Usd.Stage.Open(os.path.join(data_dir, "stage1.usd"))
     session.ensight.objs.core.PARTS.set_attr("COLORBYPALETTE", "alpha1")
     session.ensight.utils.omniverse.update()
-    assert wait_for_idle(session)
+    assert wait_for_complete(session)
     stage2 = Usd.Stage.Open(base_usd)
     diff = compare_usd_files(stage1, stage2)
     assert diff is False
     diff = compare_usd_files(temp_stage, stage2)
     assert diff is True
     session.ensight.utils.omniverse.update(temporal=True)
-    assert wait_for_idle(session)
+    assert wait_for_complete(session)
     parts = glob.glob(os.path.join(data_dir, "Parts", "*.usd"))
     # Considering deduplication, at the end of the export there will be 39 items
     # not 100 (5*20)


### PR DESCRIPTION
Include num timesteps and total timesteps in the status update.
Use 'complete' for the final status instead of going back to 'idle'.  It is sometimes helpful to distinguish between 'complete' and 'not started'.
https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_workitems/edit/1447908