### PR TITLE
feat: USD exports can take a time_scale option

### DIFF
--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -1068,12 +1068,38 @@ class DSGSession(object):
         )
         self._update_status_file()
 
+        tmp_ts = None
+
         # handle the various commands until UPDATE_SCENE_END
         cmd = self._get_next_message()
         while (cmd is not None) and (
             cmd.command_type != dynamic_scene_graph_pb2.SceneUpdateCommand.UPDATE_SCENE_END
         ):
             self._handle_update_command(cmd)
+
+            # Check for a time_scale option, attached to the group attrs.
+            # It overrides the time_scale used as a launch option
+            if (
+                tmp_ts is None
+                and cmd.command_type == dynamic_scene_graph_pb2.SceneUpdateCommand.UPDATE_GROUP
+            ):
+                group = self._groups[cmd.update_group.id]
+                if self._callback_handler and hasattr(
+                    self._callback_handler, "get_dsg_cmd_attribute"
+                ):
+                    ts_str = self._callback_handler.get_dsg_cmd_attribute(group, "time_scale")
+                    if ts_str is None:
+                        tmp_ts = self._time_scale
+                    else:
+                        try:
+                            tmp_ts = float(ts_str)
+                        except ValueError:
+                            tmp_ts = self._time_scale
+                    if self._time_scale != tmp_ts:
+                        if self._time_scale != 0.0:
+                            self.cur_timeline[0] = tmp_ts * self.cur_timeline[0] / self._time_scale
+                            self.cur_timeline[1] = tmp_ts * self.cur_timeline[1] / self._time_scale
+                        self._time_scale = tmp_ts
 
             if cmd.command_type == dynamic_scene_graph_pb2.SceneUpdateCommand.UPDATE_VIEW:
                 if hasattr(cmd.update_view, "num_timesteps") and cmd.update_view.num_timesteps > 0:
@@ -1092,7 +1118,7 @@ class DSGSession(object):
         self._callback_handler.end_update()
 
         # Update our status
-        self._status = dict(status="complete", start_time=0.0, processed_buffers=0, total_buffers=0)
+        self._status["status"] = "complete"
         self._update_status_file()
 
     def _handle_update_command(self, cmd: dynamic_scene_graph_pb2.SceneUpdateCommand) -> None:

--- a/src/ansys/pyensight/core/utils/omniverse.py
+++ b/src/ansys/pyensight/core/utils/omniverse.py
@@ -820,7 +820,9 @@ class Omniverse:
         self._server_pid = None
         self._new_status_file(new=False)
 
-    def update(self, temporal: bool = False, line_width: float = 0.0) -> None:
+    def update(
+        self, temporal: bool = False, line_width: float = 0.0, time_scale: Optional[float] = None
+    ) -> None:
         """Update the geometry in Omniverse
 
         Export the current EnSight scene to the current Omniverse connection.
@@ -849,6 +851,10 @@ class Omniverse:
             if add_linewidth:
                 update_cmd += f"{prefix}ANSYS_linewidth={line_width}"
                 prefix = "&"
+        if time_scale is not None:
+            update_cmd += f"{prefix}time_scale={time_scale}"
+            prefix = "&"
+
         self._check_modules()
         if not self.is_running_omniverse():
             raise RuntimeError("No Omniverse server connection is currently active.")


### PR DESCRIPTION
Allow a time scale option to be passed through the omniverse.update() utility and processed by the dsg service.
Previously, time_scale could only be set on the command line.

https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_workitems/edit/1466657/?workitem=1437037