### PR TITLE
feat: better 'special' value to indicate default line width

### DIFF
--- a/src/ansys/pyensight/core/utils/omniverse.py
+++ b/src/ansys/pyensight/core/utils/omniverse.py
@@ -737,7 +737,7 @@ class Omniverse:
         if time_scale != 1.0:
             cmd.extend(["--time_scale", str(time_scale)])
         if line_width != 0.0:
-            cmd.extend(["--line_width", str(line_width)])
+            cmd.extend(["--line_width=" + str(line_width)])
         if not live:
             cmd.extend(["--oneshot", "1"])
         if grpc_allow_network_connectsion:

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -1150,7 +1150,8 @@ class OmniverseUpdateHandler(UpdateHandler):
                     except ValueError:
                         pass
 
-                if width == -1.0:
+                LINE_WIDTH_AUTO = -1.2345e-10
+                if math.isclose(width, LINE_WIDTH_AUTO, rel_tol=1e-6, abs_tol=1e-15):
                     # Generate a line width proportional to the median line segment length.
                     line_width_proportion = 0.05
                     tmp = verts.reshape(-1, 2, 3)
@@ -1173,6 +1174,10 @@ class OmniverseUpdateHandler(UpdateHandler):
                     width = diagonal * math.fabs(width) / self._omni._units_per_meter
                     if self._omni.line_width < 0.0:
                         self._omni.line_width = width
+                # Pass the computed line width out through the status file.
+                if isinstance(self.session._status, dict):
+                    self.session._status["line_width"] = width
+
                 width = width * self._omni._units_per_meter
                 # Generate the lines
                 _ = self._omni.create_dsg_lines(

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -497,7 +497,7 @@ class OmniverseWrapper(object):
             vc_attr.Set([2] * (verts.size // 6), 0)
         lines.CreatePurposeAttr().Set("render")
         lines.CreateTypeAttr().Set("linear")
-        lines.CreateWidthsAttr([width])
+        lines.CreateWidthsAttr([float(width)])
         lines.SetWidthsInterpolation("constant")
 
         # Rounded endpoint are a primvar
@@ -506,12 +506,6 @@ class OmniverseWrapper(object):
             "endcaps", Sdf.ValueTypeNames.Int, UsdGeom.Tokens.constant
         )
         endCaps.Set(2)  # Rounded = 2
-
-        prim = lines.GetPrim()
-        wireframe = width == 0.0
-        prim.CreateAttribute("omni:scene:visualization:drawWireframe", Sdf.ValueTypeNames.Bool).Set(
-            wireframe
-        )
 
         if (tcoords is not None) and var_cmd:
             primvarsAPI = UsdGeom.PrimvarsAPI(lines)
@@ -838,7 +832,7 @@ class OmniverseWrapper(object):
             # LOL, not sure why is might be correct, but so far it seems to work???
             cam.focalLength = camera.fieldofview
             dist = (target_pos - cam_pos).GetLength()
-            cam.clippingRange = Gf.Range1f(0.1 * dist, 1000.0 * dist)
+            cam.clippingRange = Gf.Range1f(0.01 * dist, 1000.0 * dist)
             look_at = Gf.Matrix4d()
             look_at.SetLookAt(cam_pos, target_pos, up_vec)
             trans_row = look_at.GetRow(3)
@@ -1131,7 +1125,7 @@ class OmniverseUpdateHandler(UpdateHandler):
             if verts is not None:
                 verts = numpy.multiply(verts, self._omni._units_per_meter)
             if command is not None:
-                # If there are no triangle (ideally if these are not hidden line
+                # If there are no triangles (ideally if these are not hidden line
                 # edges), then use the base color for the part.  If there are
                 # triangles, then assume these are hidden line edges and use the
                 # line_color.
@@ -1155,7 +1149,20 @@ class OmniverseUpdateHandler(UpdateHandler):
                         width = float(group.attributes.get("ANSYS_linewidth", str(width)))
                     except ValueError:
                         pass
-                if width < 0.0:
+
+                if width == -1.0:
+                    # Generate a line width proportional to the median line segment length.
+                    line_width_proportion = 0.05
+                    tmp = verts.reshape(-1, 2, 3)
+                    seg_lengths = numpy.linalg.norm(tmp[:, 1, :] - tmp[:, 0, :], axis=1)
+                    width = (
+                        float(numpy.median(seg_lengths) * line_width_proportion)
+                        / self._omni._units_per_meter
+                    )
+                    if self._omni.line_width < 0.0:
+                        self._omni.line_width = width
+
+                elif width < 0.0:
                     tmp = verts.reshape(-1, 3)
                     mins = numpy.min(tmp, axis=0)
                     maxs = numpy.max(tmp, axis=0)


### PR DESCRIPTION
I changed the 'special' line width value to -1.2345e-10.  This is used in EnSight quite a bit, mainly as the undef value.  If passed from EnSight or F1 to an older pyensight that doesn't recognize it, -1.2345e-10 would just result in thin lines.  No big deal.  The previous value of -1 could likely cause an Omniverse crash if pyensight did not handle it specially.  

I also pass the computed line width back out through the status file.  Users can export once using a automatically chosen line width.  On subsequent exports, users can adjust this line width as needed.

https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_workitems/edit/1486527/