### PR TITLE
fix: Improve handling long USD file names and folders

### DIFF
--- a/src/ansys/pyensight/core/utils/dsg_server.py
+++ b/src/ansys/pyensight/core/utils/dsg_server.py
@@ -77,7 +77,8 @@ class Part(object):
         self.tcoords_elem = False
         self.node_sizes = numpy.array([], dtype="float32")
         self.cmd: Optional[Any] = None
-        self.hash = hashlib.new("sha256")
+        # digest_size==12 means 96 bit hash size.  Decodes to 24 hex characters.
+        self.hash = hashlib.blake2b(digest_size=12)
         self._material: Optional[Any] = None
         self.reset()
 
@@ -103,7 +104,7 @@ class Part(object):
         self.tcoords_var_id = None
         self.tcoords_elem = False
         self.node_sizes = numpy.array([], dtype="float32")
-        self.hash = hashlib.new("sha256")
+        self.hash = hashlib.blake2b(digest_size=12)
         if cmd is not None:
             self.hash.update(cmd.hash.encode("utf-8"))
         self.cmd = cmd

--- a/src/ansys/pyensight/core/utils/omniverse.py
+++ b/src/ansys/pyensight/core/utils/omniverse.py
@@ -843,17 +843,16 @@ class Omniverse:
         if temporal:
             update_cmd += f"{prefix}timesteps=1"
             prefix = "&"
-        if line_width != 0.0:
-            add_linewidth = False
-            if isinstance(self._ensight, ModuleType):
+        add_linewidth = False
+        if isinstance(self._ensight, ModuleType):
+            add_linewidth = True
+        else:
+            # only in 2025 R2 and beyond
+            if self._ensight._session.ensight_version_check("2025 R2", exception=False):
                 add_linewidth = True
-            else:
-                # only in 2025 R2 and beyond
-                if self._ensight._session.ensight_version_check("2025 R2", exception=False):
-                    add_linewidth = True
-            if add_linewidth:
-                update_cmd += f"{prefix}ANSYS_linewidth={line_width}"
-                prefix = "&"
+        if add_linewidth:
+            update_cmd += f"{prefix}ANSYS_linewidth={line_width}"
+            prefix = "&"
         if time_scale is not None:
             update_cmd += f"{prefix}time_scale={time_scale}"
             prefix = "&"

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -24,6 +24,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 ###############################################################################
+import ctypes
 import logging
 import math
 import os
@@ -89,9 +90,14 @@ class OmniverseWrapper(object):
 
     @destination.setter
     def destination(self, directory: str) -> None:
-        self._destinationPath = directory
-        if not self.is_valid_destination(directory):
-            logging.warning(f"Invalid destination path: {directory}")
+        """Sets the destination directory. Creates dir and parents as needed.
+        Converts dir to short path, to mitigate USD library limitations with long paths.
+        Throws exceptions if the directory cannot be created -
+        for example, if a parent dir is not writable, or 'directory' exists and is a file."""
+        os.makedirs(directory, exist_ok=True)
+        self._destinationPath = self.short_path(directory)
+        if not self.is_valid_destination(self._destinationPath):
+            logging.warning(f"Invalid destination path: {self._destinationPath}")
 
     @property
     def line_width(self) -> float:
@@ -122,6 +128,27 @@ class OmniverseWrapper(object):
             True if the path is a writeable directory, False otherwise.
         """
         return os.access(path, os.W_OK)
+
+    @staticmethod
+    def short_path(path: str) -> str:
+        """Return the Windows 8.3 short path form. Falls back to the original path."""
+        if not path or "win" not in platform.system().lower():
+            return path
+        try:
+            GetShortPathNameW = ctypes.windll.kernel32.GetShortPathNameW
+            GetShortPathNameW.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32]
+            GetShortPathNameW.restype = ctypes.c_uint32
+
+            # First call: query required buffer size (including terminating NUL).
+            needed = GetShortPathNameW(path, None, 0)
+            if needed == 0:
+                return path
+            buf = ctypes.create_unicode_buffer(needed)
+            if GetShortPathNameW(path, buf, needed) == 0:
+                return path
+            return buf.value
+        except Exception:
+            return path
 
     def stage_url(self, name: Optional[str] = None) -> str:
         """

--- a/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
+++ b/src/ansys/pyensight/core/utils/omniverse_dsg_server.py
@@ -135,7 +135,7 @@ class OmniverseWrapper(object):
         if not path or "win" not in platform.system().lower():
             return path
         try:
-            GetShortPathNameW = ctypes.windll.kernel32.GetShortPathNameW
+            GetShortPathNameW = getattr(ctypes, "windll").kernel32.GetShortPathNameW
             GetShortPathNameW.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32]
             GetShortPathNameW.restype = ctypes.c_uint32
 


### PR DESCRIPTION
Anna reported a problem exporting USD files within the new project folder structure.  The cause was found to be fully qualified file names longer than the system limit of 260 characters.

The problem cannot be fully solved, but this PR mitigates the problem.

1) I shortened the hash so it adds 24 characters instead of 62.  
2) I find and use the 8.3 form of the destination folder.  Any longer folder names in the output path are shortened to 8 characters.
Internally, "C:\Users\djbremer\Downloads\Butterfly_Valve_2April2026_Perforatedplate_files\simulation_1\design_points\dpall\components\post_1"
is replaced by "C:/Users/djbremer/DOWNLO~1/BUTTER~2/SIMULA~1/DESIGN~1/dpall/COMPON~1/post_1/ "


https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_workitems/edit/1494350
